### PR TITLE
SC-119: Adds dependency injection extension method

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -9,6 +9,10 @@ for the SDK to send data to the Enterspeed Ingest API.
 
 List of implementations that the SDK ships with.
 
+## [Dependency Injection](./dependency-injection/README.md)
+
+Extension methods for dependency injection.
+
 ## [Enterspeed Connection](./connection/README.md)
 
 The connection for Enterspeed.

--- a/documentation/dependency-injection/README.md
+++ b/documentation/dependency-injection/README.md
@@ -1,0 +1,19 @@
+# Dependency Injection
+
+## UseEnterspeedIngestService
+
+An extension method to easily add the Enterspeed Ingest Service for dependency injection.
+
+Example:
+
+```csharp
+using Enterspeed.Source.Sdk.Extensions.NETCore.Setup;
+
+serviceCollection.AddEnterspeedIngestService(new EnterspeedConfiguration
+{
+    ApiKey = "source-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    BaseUrl = "https://api.enterspeed.com"
+});
+```
+
+See [Enterspeed Configuration](../configuration/README.md) for configuration details.

--- a/src/Enterspeed.Source.Sdk/Api/Models/EnterspeedEntity.cs
+++ b/src/Enterspeed.Source.Sdk/Api/Models/EnterspeedEntity.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using Enterspeed.Source.Sdk.Api.Models.Properties;
+
+namespace Enterspeed.Source.Sdk.Api.Models
+{
+    public class EnterspeedEntity : IEnterspeedEntity
+    {
+        public string Id { get; }
+        public string Type { get; }
+        public string Url { get; }
+        public string[] Redirects { get; }
+        public string ParentId { get; }
+        public IDictionary<string, IEnterspeedProperty> Properties { get; }
+    }
+}

--- a/src/Enterspeed.Source.Sdk/Domain/Providers/EnterspeedConfigurationProvider.cs
+++ b/src/Enterspeed.Source.Sdk/Domain/Providers/EnterspeedConfigurationProvider.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Enterspeed.Source.Sdk.Api.Providers;
+using Enterspeed.Source.Sdk.Configuration;
+
+namespace Enterspeed.Source.Sdk.Domain.Providers
+{
+    public class EnterspeedConfigurationProvider : IEnterspeedConfigurationProvider
+    {
+        public EnterspeedConfiguration Configuration { get; }
+
+        public EnterspeedConfigurationProvider(EnterspeedConfiguration configuration)
+        {
+            Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        }
+    }
+}

--- a/src/Enterspeed.Source.Sdk/Enterspeed.Source.Sdk.csproj
+++ b/src/Enterspeed.Source.Sdk/Enterspeed.Source.Sdk.csproj
@@ -22,6 +22,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions">
+      <Version>6.0.0</Version>
+    </PackageReference>
     <PackageReference Include="System.Text.Json" Version="[5.0,6.0)" />
   </ItemGroup>
 

--- a/src/Enterspeed.Source.Sdk/Extensions/NETCore/Setup/ServiceCollectionExtensions.cs
+++ b/src/Enterspeed.Source.Sdk/Extensions/NETCore/Setup/ServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+﻿#if NETSTANDARD2_0_OR_GREATER
+using Enterspeed.Source.Sdk.Api.Connection;
+using Enterspeed.Source.Sdk.Api.Providers;
+using Enterspeed.Source.Sdk.Api.Services;
+using Enterspeed.Source.Sdk.Configuration;
+using Enterspeed.Source.Sdk.Domain.Connection;
+using Enterspeed.Source.Sdk.Domain.Providers;
+using Enterspeed.Source.Sdk.Domain.Services;
+using Enterspeed.Source.Sdk.Domain.SystemTextJson;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Enterspeed.Source.Sdk.Extensions.NETCore.Setup
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddEnterspeedIngestService(
+            this IServiceCollection services,
+            EnterspeedConfiguration configuration)
+        {
+            services.AddScoped<IEnterspeedConnection, EnterspeedConnection>();
+            services.AddScoped<IEnterspeedIngestService, EnterspeedIngestService>();
+            services.AddScoped<IJsonSerializer, SystemTextJsonSerializer>();
+            services.AddSingleton<IEnterspeedConfigurationProvider>(
+                new EnterspeedConfigurationProvider(configuration));
+
+            return services;
+        }
+    }
+}
+#endif

--- a/tests/Enterspeed.Source.Sdk.Tests/Api/Models/EnterspeedEntityTest.cs
+++ b/tests/Enterspeed.Source.Sdk.Tests/Api/Models/EnterspeedEntityTest.cs
@@ -1,0 +1,16 @@
+﻿using Enterspeed.Source.Sdk.Api.Models;
+using Xunit;
+
+namespace Enterspeed.Source.Sdk.Tests.Api.Models
+{
+    public class EnterspeedEntityTest
+    {
+        [Fact]
+        public void EnterspeedEntity_ImplementsInterface()
+        {
+            var entity = new EnterspeedEntity();
+
+            Assert.IsAssignableFrom<IEnterspeedEntity>(entity);
+        }
+    }
+}

--- a/tests/Enterspeed.Source.Sdk.Tests/Domain/Providers/EnterspeedConfigurationProviderTest.cs
+++ b/tests/Enterspeed.Source.Sdk.Tests/Domain/Providers/EnterspeedConfigurationProviderTest.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Enterspeed.Source.Sdk.Configuration;
+using Enterspeed.Source.Sdk.Domain.Providers;
+using Xunit;
+
+namespace Enterspeed.Source.Sdk.Tests.Domain.Providers
+{
+    public class EnterspeedConfigurationProviderTest
+    {
+        [Fact]
+        public void ConfigurationProvider_Success()
+        {
+            var configuration = new EnterspeedConfiguration();
+            var configurationProvider = new EnterspeedConfigurationProvider(configuration);
+
+            Assert.Equal(configuration, configurationProvider.Configuration);
+        }
+
+        [Fact]
+        public void ConfigurationProvider_MissingConfiguration()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new EnterspeedConfigurationProvider(null));
+
+            Assert.Equal("configuration", exception.ParamName);
+        }
+    }
+}

--- a/tests/Enterspeed.Source.Sdk.Tests/Enterspeed.Source.Sdk.Tests.csproj
+++ b/tests/Enterspeed.Source.Sdk.Tests/Enterspeed.Source.Sdk.Tests.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.15.0" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.15.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />

--- a/tests/Enterspeed.Source.Sdk.Tests/Extensions/NETCoreSetupTest.cs
+++ b/tests/Enterspeed.Source.Sdk.Tests/Extensions/NETCoreSetupTest.cs
@@ -1,0 +1,56 @@
+﻿#if NETSTANDARD2_0_OR_GREATER
+using System;
+using Enterspeed.Source.Sdk.Api.Connection;
+using Enterspeed.Source.Sdk.Api.Providers;
+using Enterspeed.Source.Sdk.Api.Services;
+using Enterspeed.Source.Sdk.Configuration;
+using Enterspeed.Source.Sdk.Domain.Connection;
+using Enterspeed.Source.Sdk.Domain.Providers;
+using Enterspeed.Source.Sdk.Domain.Services;
+using Enterspeed.Source.Sdk.Domain.SystemTextJson;
+using Enterspeed.Source.Sdk.Extensions.NETCore.Setup;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Enterspeed.Source.Sdk.Tests.Extensions
+{
+    public class NETCoreSetupTest
+    {
+        [Fact]
+        public void AddEnterspeedIngestService_Success()
+        {
+            IServiceCollection serviceCollection = new ServiceCollection();
+
+            var configuration = new EnterspeedConfiguration
+            {
+                ApiKey = "source-" + Guid.NewGuid(),
+                BaseUrl = "https://example.com"
+            };
+
+            serviceCollection.AddEnterspeedIngestService(configuration);
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            var ingestService = serviceProvider.GetService<IEnterspeedIngestService>();
+            var connection = serviceProvider.GetService<IEnterspeedConnection>();
+            var serializer = serviceProvider.GetService<IJsonSerializer>();
+            var configurationProvider = serviceProvider.GetService<IEnterspeedConfigurationProvider>();
+
+            Assert.IsType<EnterspeedIngestService>(ingestService);
+            Assert.IsType<EnterspeedConnection>(connection);
+            Assert.IsType<SystemTextJsonSerializer>(serializer);
+            Assert.IsType<EnterspeedConfigurationProvider>(configurationProvider);
+
+            Assert.Equal(configuration, configurationProvider.Configuration);
+        }
+
+        [Fact]
+        public void AddEnterspeedIngestService_MissingConfiguration()
+        {
+            IServiceCollection serviceCollection = new ServiceCollection();
+
+            Assert.Throws<ArgumentNullException>(() => serviceCollection.AddEnterspeedIngestService(null));
+        }
+    }
+}
+#endif


### PR DESCRIPTION
```csharp
using Enterspeed.Source.Sdk.Extensions.NETCore.Setup;

serviceCollection.AddEnterspeedIngestService(new EnterspeedConfiguration
{
    ApiKey = "source-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
    BaseUrl = "https://api.enterspeed.com"
});
```