### PR TITLE
Feature/sc 1039/upgrade our public projects from net 5 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,3 +349,6 @@ MigrationBackup/
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
 *.orig
+
+# IntelliJ, Rider and so on
+.idea/*

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,13 +23,6 @@ variables:
     semVersionRev: $[counter(variables.semVersionBase, 0)]
     semVersion: $[format('{0}.{1}', variables.semVersionBase, variables.semVersionRev)]
     buildName: $[format('Release - {0}', variables.semVersion)]
-  ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/feature/') }}:
-    # Versioning: 1.0.0-feature.branch.123
-    releaseOnNuget: false
-    semVersionBase: $[format('{0}-feature.{1}', variables.version, variables['Build.SourceBranchName'])]
-    semVersionRev: $[counter(variables.semVersionBase, 0)]
-    semVersion: $[format('{0}.{1}', variables.semVersionBase, variables.semVersionRev)]
-    buildName: $[format('Feature - {0}', variables.semVersion)]
   ${{ if startsWith(variables['Build.SourceBranch'], 'refs/pull/') }}: # Pull requests
     # Versioning: 1.0.0-pr.1.123
     releaseOnNuget: false
@@ -46,22 +39,6 @@ trigger:
       - master
       - develop
       - release/*
-      - feature/*
-      - bugfix/*
-  paths:
-    exclude:
-      - README.md
-      - CHANGELOG.md
-      - documentation/*
-
-pr:
-  branches:
-    include:
-      - master
-      - develop
-      - release/*
-      - feature/*
-      - bugfix/*
   paths:
     exclude:
       - README.md
@@ -82,7 +59,7 @@ stages:
             displayName: Install .NET 6.0 SDK
             inputs:
               packageType: sdk
-              version: '6.0.x'
+              version: "6.0.x"
 
           # NuGet
           - task: NuGetToolInstaller@1
@@ -101,8 +78,8 @@ stages:
             displayName: Dotnet build
             inputs:
               command: build
-              projects: 'Enterspeed.Sdk.sln'
-              arguments: '--configuration Release'
+              projects: "Enterspeed.Sdk.sln"
+              arguments: "--configuration Release"
 
           # Run unit tests
           - task: DotNetCoreCLI@2
@@ -111,21 +88,21 @@ stages:
               command: test
               arguments: '--no-build --configuration Release --collect:"XPlat Code Coverage"'
 
-          # Pack NuGet 
+          # Pack NuGet
           - task: DotNetCoreCLI@2
             displayName: Dotnet pack
             inputs:
               command: pack
-              packagesToPack: '**/*.csproj'
+              packagesToPack: "**/*.csproj"
               versioningScheme: byEnvVar
               versionEnvVar: semVersion
-              arguments: '--configuration Release /p:Version=$(semVersion)'
+              arguments: "--configuration Release /p:Version=$(semVersion)"
 
           # Publish artifacts
           - task: PublishPipelineArtifact@1
             displayName: Publish artifact - nupkg
             inputs:
-              targetPath: '$(Build.ArtifactStagingDirectory)'
+              targetPath: "$(Build.ArtifactStagingDirectory)"
               artifact: nupkg
 
   - stage: Release
@@ -159,6 +136,6 @@ stages:
                   displayName: Release on NuGet.org
                   inputs:
                     command: push
-                    packagesToPush: '$(Pipeline.Workspace)/**/*.nupkg;!$(Pipeline.Workspace)/**/*.symbols.nupkg'
+                    packagesToPush: "$(Pipeline.Workspace)/**/*.nupkg;!$(Pipeline.Workspace)/**/*.symbols.nupkg"
                     nuGetFeedType: external
                     publishFeedCredentials: NuGet.org

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,7 @@ trigger:
       - README.md
       - CHANGELOG.md
       - documentation/*
-   
+
 pr:
   branches:
     include:
@@ -76,15 +76,18 @@ stages:
         displayName: Build Platform
         pool:
           vmImage: windows-latest
-          demands:
-            - msbuild
-            - visualstudio
+
         steps:
+          - task: UseDotNet@2
+            displayName: Install .NET 6.0 SDK
+            inputs:
+              packageType: sdk
+              version: '6.0.x'
+
           # NuGet
           - task: NuGetToolInstaller@1
             displayName: NuGet install
-            inputs:
-              versionSpec: 4.8.1
+
           - task: NuGetCommand@2
             displayName: NuGet restore
             inputs:
@@ -94,13 +97,12 @@ stages:
               restoreDirectory: ../lib/packages
 
           # Build solution
-          - task: VSBuild@1
-            displayName: Build solution
+          - task: DotNetCoreCLI@2
+            displayName: Dotnet build
             inputs:
-              solution: ./Enterspeed.Sdk.sln
-              platform: Any CPU
-              configuration: Release
-              maximumCpuCount: true
+              command: build
+              projects: 'Enterspeed.Sdk.sln'
+              arguments: '--configuration Release'
 
           # Run unit tests
           - task: DotNetCoreCLI@2
@@ -152,7 +154,7 @@ stages:
                     script: |
                       git tag $(semVersion)
                       git push --tags
-                      
+
                 - task: NuGetCommand@2
                   displayName: Release on NuGet.org
                   inputs:

--- a/src/Enterspeed.Source.Sdk/Api/Connection/IEnterspeedConnection.cs
+++ b/src/Enterspeed.Source.Sdk/Api/Connection/IEnterspeedConnection.cs
@@ -1,8 +1,9 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 
 namespace Enterspeed.Source.Sdk.Api.Connection
 {
-    public interface IEnterspeedConnection
+    public interface IEnterspeedConnection : IDisposable
     {
         /// <summary>
         /// Gets the configured HttpClient.

--- a/src/Enterspeed.Source.Sdk/Configuration/ConfigurationException.cs
+++ b/src/Enterspeed.Source.Sdk/Configuration/ConfigurationException.cs
@@ -1,0 +1,15 @@
+using System;
+namespace Enterspeed.Source.Sdk.Configuration
+{
+    public class ConfigurationException : Exception
+    {
+        private ConfigurationException()
+        {
+        }
+
+        public ConfigurationException(string parameterName)
+            : base($"Missing {parameterName}")
+        {
+        }
+    }
+}

--- a/src/Enterspeed.Source.Sdk/Domain/Connection/EnterspeedConnection.cs
+++ b/src/Enterspeed.Source.Sdk/Domain/Connection/EnterspeedConnection.cs
@@ -3,14 +3,14 @@ using System.Net.Http;
 using System.Reflection;
 using Enterspeed.Source.Sdk.Api.Connection;
 using Enterspeed.Source.Sdk.Api.Providers;
-
+using Enterspeed.Source.Sdk.Configuration;
 namespace Enterspeed.Source.Sdk.Domain.Connection
 {
-    public class EnterspeedConnection : IEnterspeedConnection
+    public sealed class EnterspeedConnection : IEnterspeedConnection
     {
         private readonly IEnterspeedConfigurationProvider _configurationProvider;
-        private HttpClient _httpClientConnection;
         private DateTime? _connectionEstablishedDate;
+        private HttpClient _httpClientConnection;
 
         public EnterspeedConnection(IEnterspeedConfigurationProvider configurationProvider)
         {
@@ -20,7 +20,6 @@ namespace Enterspeed.Source.Sdk.Domain.Connection
         private string ApiKey => _configurationProvider.Configuration.ApiKey;
         private string BaseUrl => _configurationProvider.Configuration.BaseUrl;
         private int ConnectionTimeout => _configurationProvider.Configuration.ConnectionTimeout;
-        private string IngestVersion => _configurationProvider.Configuration.IngestVersion;
 
         public HttpClient HttpClientConnection
         {
@@ -28,7 +27,7 @@ namespace Enterspeed.Source.Sdk.Domain.Connection
             {
                 if (_httpClientConnection == null
                     || !_connectionEstablishedDate.HasValue
-                    || ((DateTime.Now - _connectionEstablishedDate.Value).TotalSeconds > ConnectionTimeout))
+                    || (DateTime.Now - _connectionEstablishedDate.Value).TotalSeconds > ConnectionTimeout)
                 {
                     Connect();
                 }
@@ -43,16 +42,21 @@ namespace Enterspeed.Source.Sdk.Domain.Connection
             _connectionEstablishedDate = null;
         }
 
+        public void Dispose()
+        {
+            _httpClientConnection.Dispose();
+        }
+
         private void Connect()
         {
             if (string.IsNullOrWhiteSpace(ApiKey))
             {
-                throw new Exception("ApiKey is missing in the connection.");
+                throw new ConfigurationException(nameof(ApiKey));
             }
 
             if (string.IsNullOrWhiteSpace(BaseUrl))
             {
-                throw new Exception("BaseUrl is missing in the connection.");
+                throw new ConfigurationException(nameof(BaseUrl));
             }
 
             _httpClientConnection = new HttpClient();
@@ -60,9 +64,9 @@ namespace Enterspeed.Source.Sdk.Domain.Connection
             _httpClientConnection.DefaultRequestHeaders.Add("X-Api-Key", ApiKey);
             _httpClientConnection.DefaultRequestHeaders.Add("Accept", "application/json");
 
-            #if NETSTANDARD2_0_OR_GREATER || NET || NETCOREAPP2_0_OR_GREATER
-            _httpClientConnection.DefaultRequestHeaders.Add("X-Enterspeed-System", $"sdk-dotnet/{Assembly.GetExecutingAssembly()?.GetName().Version?.ToString()}");
-            #endif
+#if NETSTANDARD2_0_OR_GREATER || NET || NETCOREAPP2_0_OR_GREATER
+            _httpClientConnection.DefaultRequestHeaders.Add("X-Enterspeed-System", $"sdk-dotnet/{Assembly.GetExecutingAssembly().GetName().Version}");
+#endif
 
             _connectionEstablishedDate = DateTime.Now;
         }

--- a/src/Enterspeed.Source.Sdk/Domain/SystemTextJson/EnterspeedPropertyConverter.cs
+++ b/src/Enterspeed.Source.Sdk/Domain/SystemTextJson/EnterspeedPropertyConverter.cs
@@ -1,11 +1,10 @@
-﻿#if NETSTANDARD2_0
+﻿#if NETSTANDARD2_0 || NET6_0
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Enterspeed.Source.Sdk.Api.Models.Properties;
-
 namespace Enterspeed.Source.Sdk.Domain.SystemTextJson
 {
     public class EnterspeedPropertyConverter : JsonConverter<IEnterspeedProperty>

--- a/src/Enterspeed.Source.Sdk/Domain/SystemTextJson/HttpStatusCodeConverter.cs
+++ b/src/Enterspeed.Source.Sdk/Domain/SystemTextJson/HttpStatusCodeConverter.cs
@@ -1,16 +1,15 @@
-﻿#if NETSTANDARD2_0
+﻿#if NETSTANDARD2_0 || NET6_0
 using System;
 using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-
 namespace Enterspeed.Source.Sdk.Domain.SystemTextJson
 {
     public class HttpStatusCodeConverter : JsonConverter<HttpStatusCode>
     {
         public override HttpStatusCode Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            var couldParse = Enum.TryParse<HttpStatusCode>(reader.GetInt32().ToString(), out var statusCode);
+            Enum.TryParse<HttpStatusCode>(reader.GetInt32().ToString(), out var statusCode);
 
             return statusCode;
         }

--- a/src/Enterspeed.Source.Sdk/Domain/SystemTextJson/SystemTextJsonSerializer.cs
+++ b/src/Enterspeed.Source.Sdk/Domain/SystemTextJson/SystemTextJsonSerializer.cs
@@ -1,7 +1,6 @@
-﻿#if NETSTANDARD2_0
+﻿#if NETSTANDARD2_0 || NET6_0
 using System.Text.Json;
 using Enterspeed.Source.Sdk.Api.Services;
-
 namespace Enterspeed.Source.Sdk.Domain.SystemTextJson
 {
     public class SystemTextJsonSerializer : IJsonSerializer

--- a/src/Enterspeed.Source.Sdk/Enterspeed.Source.Sdk.csproj
+++ b/src/Enterspeed.Source.Sdk/Enterspeed.Source.Sdk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard1.1;netstandard2.0</TargetFrameworks>
 
     <PackageId>Enterspeed.Source.Sdk</PackageId>
     <Authors>Enterspeed</Authors>

--- a/tests/Enterspeed.Source.Sdk.Tests/Domain/Connection/EnterspeedConnectionTests.cs
+++ b/tests/Enterspeed.Source.Sdk.Tests/Domain/Connection/EnterspeedConnectionTests.cs
@@ -8,20 +8,20 @@ using Enterspeed.Source.Sdk.Configuration;
 using Enterspeed.Source.Sdk.Domain.Connection;
 using NSubstitute;
 using Xunit;
-
 namespace Enterspeed.Source.Sdk.Tests.Domain.Connection
 {
     public class EnterspeedConnectionTests
     {
         public class EnterspeedConnectionTestFixture : Fixture
         {
-            public IEnterspeedConfigurationProvider ConfigurationProvider { get; set; }
             public EnterspeedConnectionTestFixture()
             {
                 Customize(new AutoNSubstituteCustomization());
 
                 ConfigurationProvider = this.Freeze<IEnterspeedConfigurationProvider>();
             }
+
+            public IEnterspeedConfigurationProvider ConfigurationProvider { get; set; }
         }
 
         public class HttpClientConnection
@@ -33,7 +33,7 @@ namespace Enterspeed.Source.Sdk.Tests.Domain.Connection
 
                 fixture.ConfigurationProvider
                     .Configuration
-                    .Returns(new EnterspeedConfiguration()
+                    .Returns(new EnterspeedConfiguration
                     {
                         ApiKey = "source-" + Guid.NewGuid(),
                         BaseUrl = "https://example.com/"
@@ -51,14 +51,14 @@ namespace Enterspeed.Source.Sdk.Tests.Domain.Connection
 
                 fixture.ConfigurationProvider
                     .Configuration
-                    .Returns(new EnterspeedConfiguration()
+                    .Returns(new EnterspeedConfiguration
                     {
                         BaseUrl = "https://example.com/"
                     });
 
                 var sut = fixture.Create<EnterspeedConnection>();
 
-                Assert.Throws<Exception>(() => sut.HttpClientConnection);
+                Assert.Throws<ConfigurationException>(() => sut.HttpClientConnection);
             }
 
             [Fact]
@@ -68,14 +68,14 @@ namespace Enterspeed.Source.Sdk.Tests.Domain.Connection
 
                 fixture.ConfigurationProvider
                     .Configuration
-                    .Returns(new EnterspeedConfiguration()
+                    .Returns(new EnterspeedConfiguration
                     {
                         ApiKey = "source-" + Guid.NewGuid()
                     });
 
                 var sut = fixture.Create<EnterspeedConnection>();
 
-                Assert.Throws<Exception>(() => sut.HttpClientConnection);
+                Assert.Throws<ConfigurationException>(() => sut.HttpClientConnection);
             }
 
             [Fact]
@@ -86,7 +86,7 @@ namespace Enterspeed.Source.Sdk.Tests.Domain.Connection
                 var apiKey = "source-" + Guid.NewGuid();
                 fixture.ConfigurationProvider
                     .Configuration
-                    .Returns(new EnterspeedConfiguration()
+                    .Returns(new EnterspeedConfiguration
                     {
                         ApiKey = apiKey,
                         BaseUrl = "https://example.com/"
@@ -102,7 +102,7 @@ namespace Enterspeed.Source.Sdk.Tests.Domain.Connection
             {
                 var fixture = new EnterspeedConnectionTestFixture();
 
-                var enterspeedConfiguration = new EnterspeedConfiguration()
+                var enterspeedConfiguration = new EnterspeedConfiguration
                 {
                     ApiKey = "source-" + Guid.NewGuid(),
                     BaseUrl = "https://example.com/",
@@ -135,7 +135,7 @@ namespace Enterspeed.Source.Sdk.Tests.Domain.Connection
 
                 fixture.ConfigurationProvider
                     .Configuration
-                    .Returns(new EnterspeedConfiguration()
+                    .Returns(new EnterspeedConfiguration
                     {
                         ApiKey = "source-" + Guid.NewGuid(),
                         BaseUrl = "https://example.com/"

--- a/tests/Enterspeed.Source.Sdk.Tests/Enterspeed.Source.Sdk.Tests.csproj
+++ b/tests/Enterspeed.Source.Sdk.Tests/Enterspeed.Source.Sdk.Tests.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 	
     <CodeAnalysisRuleSet>..\..\lib\settings\Enterspeed.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgrading to .NET6 with backward compatibility

A downside of keeping backward compatibility is the need to cater to the lowest common denominator. Hence, the code must be written in a old C# 7.3 version. 

Thoughts about how to keep support for legacy system while still driving our development forwards, and staying on top with latest updates for security matters and to ease development have been written in [confluence](https://novicell.atlassian.net/wiki/spaces/Enterspeed/pages/3619193012/Enterspeed+SDK+.NET+runtime+upgrades).
