### PR TITLE
Ingest ParentId as OriginParentId if using ingest v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [Unreleased]
+### Fixed
+- `parentId` on ingested source entity is only saved if `properties` is of type `IDictionary<string, IEnterspeedProperty>`
+
 ## [2.0.1 - 2023-12-11]
 ### Changed
 - Updated dependency on `Microsoft.Extensions.DependencyInjection.Abstractions` to version 8

--- a/src/Enterspeed.Source.Sdk/Api/Models/EnterspeedEntity.cs
+++ b/src/Enterspeed.Source.Sdk/Api/Models/EnterspeedEntity.cs
@@ -33,4 +33,24 @@
             Properties = properties;
         }
     }
+
+    internal class EnterspeedEntityV2<T> : IEnterspeedEntityV2<T>
+    {
+        public string Id { get; set; }
+        public string Type { get; set; }
+        public string Url { get; set; }
+        public string[] Redirects { get; set; }
+        public string OriginParentId { get; set; }
+        public T Properties { get; set; }
+
+        public EnterspeedEntityV2(IEnterspeedEntity<T>  enterspeedEntity)
+        {
+            Id = enterspeedEntity.Id;
+            Type = enterspeedEntity.Type;
+            Url = enterspeedEntity.Url;
+            Redirects = enterspeedEntity.Redirects;
+            OriginParentId = enterspeedEntity.ParentId;
+            Properties = enterspeedEntity.Properties;
+        }
+    }
 }

--- a/src/Enterspeed.Source.Sdk/Api/Models/IEnterspeedEntity.cs
+++ b/src/Enterspeed.Source.Sdk/Api/Models/IEnterspeedEntity.cs
@@ -72,4 +72,39 @@ namespace Enterspeed.Source.Sdk.Api.Models
         /// </summary>
         T Properties { get; }
     }
+
+    internal interface IEnterspeedEntityV2<T>
+    {
+        /// <summary>
+        /// The id of your source entity. It will become OriginId in Enterspeed
+        /// </summary>
+        string Id { get; }
+
+        /// <summary>
+        /// The type of your source entity. E.g. contentPage, product, media
+        /// </summary>
+        string Type { get; }
+
+        /// <summary>
+        /// The URL of your source entity. Typically used if your source entity is a CMS page or anything else with a URL
+        /// </summary>
+        string Url { get; }
+
+        /// <summary>
+        /// Incoming redirects on your source entity. Typically used if your source entity is a CMS page or anything else with a URL
+        /// </summary>
+        string[] Redirects { get; }
+
+        /// <summary>
+        /// The parent id of your source entity. Used if your source entities has a hierarchical structure. It will become OriginParentId in Enterspeed
+        /// </summary>
+        string OriginParentId { get; }
+
+        /// <summary>
+        /// Must be a string as a serialized json object containing data properties for your source entity<br/>
+        /// or <br/>
+        /// Any object containing data properties for your source entity
+        /// </summary>
+        T Properties { get; }
+    }
 }

--- a/src/Enterspeed.Source.Sdk/Configuration/EnterspeedConfiguration.cs
+++ b/src/Enterspeed.Source.Sdk/Configuration/EnterspeedConfiguration.cs
@@ -18,11 +18,6 @@
         public int ConnectionTimeout { get; set; } = 60;
 
         /// <summary>
-        /// Gets the current version for the Ingest Endpoint.
-        /// </summary>
-        public string IngestVersion => "1";
-
-        /// <summary>
         /// Gets or sets the SystemInformation.
         /// </summary>
         public string SystemInformation { get; set; }

--- a/src/Enterspeed.Source.Sdk/Domain/Connection/IngestVersion.cs
+++ b/src/Enterspeed.Source.Sdk/Domain/Connection/IngestVersion.cs
@@ -1,0 +1,8 @@
+﻿namespace Enterspeed.Source.Sdk.Domain.Connection
+{
+    public enum IngestVersion
+    {
+        V1 = 1,
+        V2 = 2
+    }
+}

--- a/src/Enterspeed.Source.Sdk/Domain/Services/EnterspeedIngestService.cs
+++ b/src/Enterspeed.Source.Sdk/Domain/Services/EnterspeedIngestService.cs
@@ -7,7 +7,6 @@ using System.Text;
 using Enterspeed.Source.Sdk.Api.Connection;
 using Enterspeed.Source.Sdk.Api.Models;
 using Enterspeed.Source.Sdk.Api.Models.Properties;
-using Enterspeed.Source.Sdk.Api.Providers;
 using Enterspeed.Source.Sdk.Api.Services;
 using Enterspeed.Source.Sdk.Domain.Connection;
 
@@ -17,20 +16,13 @@ namespace Enterspeed.Source.Sdk.Domain.Services
     {
         private readonly IEnterspeedConnection _connection;
         private readonly IJsonSerializer _jsonSerializer;
-        private readonly IEnterspeedConfigurationProvider _configurationProvider;
-        private readonly string _ingestEndpoint;
-        private readonly string _ingestEndpointV2;
 
         public EnterspeedIngestService(
             IEnterspeedConnection connection,
-            IJsonSerializer jsonSerializer,
-            IEnterspeedConfigurationProvider configurationProvider)
+            IJsonSerializer jsonSerializer)
         {
             _connection = connection;
             _jsonSerializer = jsonSerializer;
-            _configurationProvider = configurationProvider;
-            _ingestEndpoint = $"/ingest/v{configurationProvider.Configuration.IngestVersion}";
-            _ingestEndpointV2 = "/ingest/v2";
         }
 
         public Response Save(IEnterspeedEntity entity)
@@ -90,7 +82,7 @@ namespace Enterspeed.Source.Sdk.Domain.Services
             // This was the default approach. We expect that everything is taken care of here.
             if (entity.Properties is IDictionary<string, IEnterspeedProperty>)
             {
-                return Ingest(entity, connection);
+                return Ingest(entity, IngestVersion.V1, connection);
             }
 
             // If properties is of type string, we expect a json string that we do not want to serialize once again
@@ -105,18 +97,13 @@ namespace Enterspeed.Source.Sdk.Domain.Services
                     ParentId = entity.ParentId
                 };
 
-                return Ingest(ingestEntity, "2", connection);
+                return Ingest(ingestEntity, IngestVersion.V2, connection);
             }
 
-            return Ingest(entity, "2", connection);
+            return Ingest(entity, IngestVersion.V2, connection);
         }
 
-        public Response Ingest<T>(IEnterspeedEntity<T> entity, IEnterspeedConnection connection)
-        {
-            return Ingest(entity, _configurationProvider.Configuration.IngestVersion, connection);
-        }
-
-        private Response Ingest<T>(IEnterspeedEntity<T> entity, string ingestVersion, IEnterspeedConnection connection)
+        private Response Ingest<T>(IEnterspeedEntity<T> entity, IngestVersion ingestVersion, IEnterspeedConnection connection)
         {
             if (entity == null)
             {
@@ -135,16 +122,16 @@ namespace Enterspeed.Source.Sdk.Domain.Services
             {
                 string jsonEntityToIngest;
                 string ingestUrl;
-                if (ingestVersion == "1")
+                if (ingestVersion == IngestVersion.V1)
                 {
                     jsonEntityToIngest = _jsonSerializer.Serialize(entity);
-                    ingestUrl = _ingestEndpoint;
+                    ingestUrl = GetIngestUrl(IngestVersion.V1);
                 }
                 else
                 {
                     var enterspeedEntityV2 = new EnterspeedEntityV2<T>(entity);
                     jsonEntityToIngest = _jsonSerializer.Serialize(enterspeedEntityV2);
-                    ingestUrl = $"{_ingestEndpointV2}/{entity.Id}";
+                    ingestUrl = GetIngestUrl(IngestVersion.V2, entity.Id);
                 }
 
                 var buffer = Encoding.UTF8.GetBytes(jsonEntityToIngest);
@@ -220,7 +207,7 @@ namespace Enterspeed.Source.Sdk.Domain.Services
             try
             {
                 response = connection.HttpClientConnection
-                    .DeleteAsync($"{_ingestEndpoint}?id={id}")
+                    .DeleteAsync(GetIngestUrl(IngestVersion.V2, id))
                     .ConfigureAwait(false)
                     .GetAwaiter()
                     .GetResult();
@@ -265,7 +252,7 @@ namespace Enterspeed.Source.Sdk.Domain.Services
                 var byteContent = new ByteArrayContent(buffer);
                 byteContent.Headers.ContentType = new MediaTypeHeaderValue("application/json");
                 response = _connection.HttpClientConnection
-                    .PostAsync(_ingestEndpoint, byteContent)
+                    .PostAsync(GetIngestUrl(IngestVersion.V2, "123"), byteContent)
                     .ConfigureAwait(false)
                     .GetAwaiter()
                     .GetResult();
@@ -295,6 +282,20 @@ namespace Enterspeed.Source.Sdk.Domain.Services
                 Status = statusCode,
                 Success = response.IsSuccessStatusCode
             };
+        }
+
+        private static string GetIngestUrl(IngestVersion version, string sourceEntityId = null)
+        {
+            var ingestUrl = $"/ingest/v{(int)version}";
+
+            if (!string.IsNullOrWhiteSpace(sourceEntityId))
+            {
+                ingestUrl += version == IngestVersion.V1
+                    ? $"?id={sourceEntityId}"
+                    : $"/{sourceEntityId}";
+            }
+
+            return ingestUrl;
         }
     }
 }


### PR DESCRIPTION
For the ingest V1 endpoint the property should be called `ParentId` but for the V2 endpoint is should be called `OriginParentId` but the `EnterspeedEntity` it's still called `ParentId` we just translate it before sending it to the endpoint.

Also the id is called `Id` for both V1 and V2 and not `OriginId`.

I think at some pooint we need to take that breaking change in the SDK, so we don't have this mess and don't called the same property different things to the user.