### PR TITLE
Update EnterspeedConnection.cs Dispose() logic

### DIFF
--- a/src/Enterspeed.Source.Sdk/Domain/Connection/EnterspeedConnection.cs
+++ b/src/Enterspeed.Source.Sdk/Domain/Connection/EnterspeedConnection.cs
@@ -45,7 +45,7 @@ namespace Enterspeed.Source.Sdk.Domain.Connection
 
         public void Dispose()
         {
-            _httpClientConnection.Dispose();
+            _httpClientConnection?.Dispose();
         }
 
         private void Connect()


### PR DESCRIPTION
Dispose may be called even if there is no active connection. Imagine that you are using it like this:

public Service(IEnterspeedIngestService enterspeedIngestService)

but you are not calling Save (or any other method on this interface). Connect() is not invoked, therefore _httpClientConnection is null.