### PR TITLE
feat [sc-8136]: add bulk ingest and bulk delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [2.1.0 - 2026-01-13]
+### Added
+- Bulk ingest functionality via `SaveBulk()` methods for ingesting multiple entities in a single HTTP request
+- Bulk delete functionality via `DeleteBulk()` methods for deleting multiple entities in a single HTTP request
+- `BulkIngestEntity` model for bulk ingest operations
+- `BulkIngestResponse` model with helper properties (`IsFullSuccess`, `IsPartialSuccess`, `IsFullFailure`, `SuccessCount`, `ErrorCount`)
+- `BulkDeleteRequest` model for bulk delete operations
+- `BulkDeleteResponse` model with helper properties for analyzing deletion results
+- Conversion extensions (`ToBulkIngestEntity`, `ToBulkIngestEntities`) for migrating from single to bulk operations
+- Response helper extensions (`GetSummary`, `GetErrorSummary`) for bulk operation responses
+- Support for .NET 9.0 target framework
+
+### Performance
+- Bulk operations provide 10-20x performance improvement over sequential single operations for batch processing
+- Reduced HTTP overhead when processing multiple entities
+
+### Requirements
+- Bulk operations require `IsAsyncBulkProcessingEnabled` feature flag to be enabled on the tenant
+- Default limits: 50 entities per request, 210MB maximum request size (configurable per tenant)
+
 ## [2.0.4 - 2024-11-22]
 ### Changed
 - Updated dependency on `Microsoft.Extensions.DependencyInjection.Abstractions` to version 9

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,6 +68,12 @@ stages:
               packageType: sdk
               version: "6.0.x"
 
+          - task: UseDotNet@2
+            displayName: Install .NET 9.0 SDK
+            inputs:
+              packageType: sdk
+              version: "9.0.x"
+
           # NuGet
           - task: NuGetToolInstaller@1
             displayName: NuGet install

--- a/src/Enterspeed.Source.Sdk/Api/Models/Bulk/BulkDeleteRequest.cs
+++ b/src/Enterspeed.Source.Sdk/Api/Models/Bulk/BulkDeleteRequest.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace Enterspeed.Source.Sdk.Api.Models.Bulk
+{
+    /// <summary>
+    /// Request model for bulk delete operations.
+    /// </summary>
+    public class BulkDeleteRequest
+    {
+        /// <summary>
+        /// Array of origin IDs to delete.
+        /// </summary>
+        public List<string> OriginIds { get; set; }
+
+        public BulkDeleteRequest()
+        {
+            OriginIds = new List<string>();
+        }
+
+        public BulkDeleteRequest(IEnumerable<string> originIds)
+        {
+            OriginIds = new List<string>(originIds);
+        }
+    }
+}
+

--- a/src/Enterspeed.Source.Sdk/Api/Models/Bulk/BulkIngestEntity.cs
+++ b/src/Enterspeed.Source.Sdk/Api/Models/Bulk/BulkIngestEntity.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+
+namespace Enterspeed.Source.Sdk.Api.Models.Bulk
+{
+    /// <summary>
+    /// Represents an entity to be ingested in a bulk operation.
+    /// Maps to the Enterspeed V2 bulk ingest API format.
+    /// </summary>
+    public class BulkIngestEntity
+    {
+        /// <summary>
+        /// The unique identifier for the entity (OriginId in Enterspeed).
+        /// </summary>
+        public string OriginId { get; set; }
+
+        /// <summary>
+        /// The type of the entity (e.g., "product", "blogPage").
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// The URL path for routable entities. Must start with '/' if provided.
+        /// </summary>
+        public string Url { get; set; }
+
+        /// <summary>
+        /// The parent entity ID for hierarchical structures (OriginParentId in Enterspeed).
+        /// </summary>
+        public string OriginParentId { get; set; }
+
+        /// <summary>
+        /// The entity's data properties.
+        /// </summary>
+        public IDictionary<string, object> Properties { get; set; }
+
+        /// <summary>
+        /// Incoming redirects for the entity.
+        /// </summary>
+        public string[] Redirects { get; set; }
+
+        public BulkIngestEntity()
+        {
+        }
+
+        public BulkIngestEntity(string originId, string type, IDictionary<string, object> properties = null)
+        {
+            OriginId = originId;
+            Type = type;
+            Properties = properties ?? new Dictionary<string, object>();
+        }
+    }
+}
+

--- a/src/Enterspeed.Source.Sdk/Api/Services/IEnterspeedIngestService.cs
+++ b/src/Enterspeed.Source.Sdk/Api/Services/IEnterspeedIngestService.cs
@@ -1,5 +1,7 @@
-﻿using Enterspeed.Source.Sdk.Api.Connection;
+﻿﻿using System.Collections.Generic;
+using Enterspeed.Source.Sdk.Api.Connection;
 using Enterspeed.Source.Sdk.Api.Models;
+using Enterspeed.Source.Sdk.Api.Models.Bulk;
 using Enterspeed.Source.Sdk.Domain.Connection;
 
 namespace Enterspeed.Source.Sdk.Api.Services
@@ -12,5 +14,50 @@ namespace Enterspeed.Source.Sdk.Api.Services
         Response Save<T>(IEnterspeedEntity<T> entity, IEnterspeedConnection connection);    
         Response Delete(string id);
         Response Delete(string id, IEnterspeedConnection connection);
+
+        /// <summary>
+        /// Bulk ingest multiple entities in a single request.
+        /// </summary>
+        /// <param name="entities">Collection of entities to ingest.</param>
+        /// <returns>Response containing results for all entities.</returns>
+        BulkIngestResponse SaveBulk(IEnumerable<BulkIngestEntity> entities);
+
+        /// <summary>
+        /// Bulk ingest multiple entities in a single request using a custom connection.
+        /// </summary>
+        /// <param name="entities">Collection of entities to ingest.</param>
+        /// <param name="connection">Custom connection to use.</param>
+        /// <returns>Response containing results for all entities.</returns>
+        BulkIngestResponse SaveBulk(IEnumerable<BulkIngestEntity> entities, IEnterspeedConnection connection);
+
+        /// <summary>
+        /// Bulk delete multiple entities by their origin IDs.
+        /// </summary>
+        /// <param name="originIds">Collection of origin IDs to delete.</param>
+        /// <returns>Response containing results for all deletions.</returns>
+        BulkDeleteResponse DeleteBulk(IEnumerable<string> originIds);
+
+        /// <summary>
+        /// Bulk delete multiple entities by their origin IDs using a custom connection.
+        /// </summary>
+        /// <param name="originIds">Collection of origin IDs to delete.</param>
+        /// <param name="connection">Custom connection to use.</param>
+        /// <returns>Response containing results for all deletions.</returns>
+        BulkDeleteResponse DeleteBulk(IEnumerable<string> originIds, IEnterspeedConnection connection);
+
+        /// <summary>
+        /// Bulk delete multiple entities using a BulkDeleteRequest.
+        /// </summary>
+        /// <param name="request">The bulk delete request.</param>
+        /// <returns>Response containing results for all deletions.</returns>
+        BulkDeleteResponse DeleteBulk(BulkDeleteRequest request);
+
+        /// <summary>
+        /// Bulk delete multiple entities using a BulkDeleteRequest and custom connection.
+        /// </summary>
+        /// <param name="request">The bulk delete request.</param>
+        /// <param name="connection">Custom connection to use.</param>
+        /// <returns>Response containing results for all deletions.</returns>
+        BulkDeleteResponse DeleteBulk(BulkDeleteRequest request, IEnterspeedConnection connection);
     }
 }

--- a/src/Enterspeed.Source.Sdk/Domain/Connection/BulkDeleteResponse.cs
+++ b/src/Enterspeed.Source.Sdk/Domain/Connection/BulkDeleteResponse.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+
+namespace Enterspeed.Source.Sdk.Domain.Connection
+{
+    /// <summary>
+    /// Response from a bulk delete operation.
+    /// </summary>
+    public class BulkDeleteResponse
+    {
+        /// <summary>
+        /// List of origin IDs that were successfully deleted.
+        /// </summary>
+        public List<string> DeletedSourceEntities { get; set; }
+
+        /// <summary>
+        /// List of origin IDs that were not found (already deleted or never existed).
+        /// This is not an error - indicates idempotent delete behavior.
+        /// </summary>
+        public List<string> NotFoundSourceEntities { get; set; }
+
+        /// <summary>
+        /// Dictionary of errors keyed by origin ID (or originIds[index] or special keys).
+        /// Each value is a list of error messages for that origin ID.
+        /// </summary>
+        public Dictionary<string, List<string>> Errors { get; set; }
+
+        /// <summary>
+        /// HTTP status code from the response.
+        /// </summary>
+        public HttpStatusCode Status { get; set; }
+
+        /// <summary>
+        /// Exception that occurred during the request, if any.
+        /// </summary>
+        public Exception Exception { get; set; }
+
+        /// <summary>
+        /// Raw response content from the API.
+        /// </summary>
+        public string Content { get; set; }
+
+        /// <summary>
+        /// Indicates whether the HTTP request was successful (2xx status code).
+        /// </summary>
+        public bool Success { get; set; }
+
+        public BulkDeleteResponse()
+        {
+            DeletedSourceEntities = new List<string>();
+            NotFoundSourceEntities = new List<string>();
+            Errors = new Dictionary<string, List<string>>();
+        }
+
+        /// <summary>
+        /// Returns true if all entities were processed successfully without errors.
+        /// Note: NotFound entities are considered successful (idempotent delete).
+        /// </summary>
+        public bool IsFullSuccess => Success && (Errors == null || Errors.Count == 0);
+
+        /// <summary>
+        /// Returns true if some entities succeeded and some failed.
+        /// </summary>
+        public bool IsPartialSuccess =>
+            Success &&
+            (DeletedSourceEntities.Count + NotFoundSourceEntities.Count) > 0 &&
+            Errors != null &&
+            Errors.Count > 0;
+
+        /// <summary>
+        /// Returns true if all entities failed or the request failed.
+        /// </summary>
+        public bool IsFullFailure =>
+            !Success ||
+            (DeletedSourceEntities.Count == 0 &&
+             NotFoundSourceEntities.Count == 0 &&
+             Errors != null &&
+             Errors.Count > 0);
+
+        /// <summary>
+        /// Gets the total number of successfully processed entities (deleted + not found).
+        /// </summary>
+        public int SuccessCount => DeletedSourceEntities.Count + NotFoundSourceEntities.Count;
+
+        /// <summary>
+        /// Gets the total number of failed entities.
+        /// </summary>
+        public int ErrorCount => Errors?.Count ?? 0;
+
+        /// <summary>
+        /// Gets all origin IDs that had errors.
+        /// </summary>
+        public IEnumerable<string> FailedOriginIds => Errors?.Keys ?? Enumerable.Empty<string>();
+
+        /// <summary>
+        /// Gets all error messages for a specific origin ID.
+        /// </summary>
+        public IEnumerable<string> GetErrorsForOriginId(string originId)
+        {
+            if (Errors != null && Errors.TryGetValue(originId, out var errors))
+            {
+                return errors;
+            }
+            return Enumerable.Empty<string>();
+        }
+    }
+}
+

--- a/src/Enterspeed.Source.Sdk/Domain/Connection/BulkIngestResponse.cs
+++ b/src/Enterspeed.Source.Sdk/Domain/Connection/BulkIngestResponse.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+
+namespace Enterspeed.Source.Sdk.Domain.Connection
+{
+    /// <summary>
+    /// Response from a bulk ingest operation.
+    /// </summary>
+    public class BulkIngestResponse
+    {
+        /// <summary>
+        /// List of origin IDs that were successfully ingested and had changes.
+        /// </summary>
+        public List<string> ChangedSourceEntities { get; set; }
+
+        /// <summary>
+        /// List of origin IDs that were processed but had no changes.
+        /// </summary>
+        public List<string> UnchangedSourceEntities { get; set; }
+
+        /// <summary>
+        /// Dictionary of errors keyed by origin ID (or entities[index] for invalid entities).
+        /// Each value is a list of error messages for that entity.
+        /// </summary>
+        public Dictionary<string, List<string>> Errors { get; set; }
+
+        /// <summary>
+        /// HTTP status code from the response.
+        /// </summary>
+        public HttpStatusCode Status { get; set; }
+
+        /// <summary>
+        /// Exception that occurred during the request, if any.
+        /// </summary>
+        public Exception Exception { get; set; }
+
+        /// <summary>
+        /// Raw response content from the API.
+        /// </summary>
+        public string Content { get; set; }
+
+        /// <summary>
+        /// Indicates whether the HTTP request was successful (2xx status code).
+        /// </summary>
+        public bool Success { get; set; }
+
+        public BulkIngestResponse()
+        {
+            ChangedSourceEntities = new List<string>();
+            UnchangedSourceEntities = new List<string>();
+            Errors = new Dictionary<string, List<string>>();
+        }
+
+        /// <summary>
+        /// Returns true if all entities were processed successfully without errors.
+        /// </summary>
+        public bool IsFullSuccess => Success && (Errors == null || Errors.Count == 0);
+
+        /// <summary>
+        /// Returns true if some entities succeeded and some failed.
+        /// </summary>
+        public bool IsPartialSuccess =>
+            Success &&
+            (ChangedSourceEntities.Count + UnchangedSourceEntities.Count) > 0 &&
+            Errors != null &&
+            Errors.Count > 0;
+
+        /// <summary>
+        /// Returns true if all entities failed or the request failed.
+        /// </summary>
+        public bool IsFullFailure =>
+            !Success ||
+            (ChangedSourceEntities.Count == 0 &&
+             UnchangedSourceEntities.Count == 0 &&
+             Errors != null &&
+             Errors.Count > 0);
+
+        /// <summary>
+        /// Gets the total number of successfully processed entities (changed + unchanged).
+        /// </summary>
+        public int SuccessCount => ChangedSourceEntities.Count + UnchangedSourceEntities.Count;
+
+        /// <summary>
+        /// Gets the total number of failed entities.
+        /// </summary>
+        public int ErrorCount => Errors?.Count ?? 0;
+
+        /// <summary>
+        /// Gets all origin IDs that had errors.
+        /// </summary>
+        public IEnumerable<string> FailedOriginIds => Errors?.Keys ?? Enumerable.Empty<string>();
+
+        /// <summary>
+        /// Gets all error messages for a specific origin ID.
+        /// </summary>
+        public IEnumerable<string> GetErrorsForOriginId(string originId)
+        {
+            if (Errors != null && Errors.TryGetValue(originId, out var errors))
+            {
+                return errors;
+            }
+            return Enumerable.Empty<string>();
+        }
+    }
+}
+

--- a/src/Enterspeed.Source.Sdk/Domain/Services/EnterspeedIngestService.cs
+++ b/src/Enterspeed.Source.Sdk/Domain/Services/EnterspeedIngestService.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using Enterspeed.Source.Sdk.Api.Connection;
 using Enterspeed.Source.Sdk.Api.Models;
+using Enterspeed.Source.Sdk.Api.Models.Bulk;
 using Enterspeed.Source.Sdk.Api.Models.Properties;
 using Enterspeed.Source.Sdk.Api.Services;
 using Enterspeed.Source.Sdk.Domain.Connection;
@@ -281,6 +283,208 @@ namespace Enterspeed.Source.Sdk.Domain.Services
             {
                 Status = statusCode,
                 Success = response.IsSuccessStatusCode
+            };
+        }
+
+        public BulkIngestResponse SaveBulk(IEnumerable<BulkIngestEntity> entities)
+        {
+            return SaveBulk(entities, _connection);
+        }
+
+        public BulkIngestResponse SaveBulk(IEnumerable<BulkIngestEntity> entities, IEnterspeedConnection connection)
+        {
+            if (entities == null)
+            {
+                return new BulkIngestResponse
+                {
+                    Success = false,
+                    Exception = new ArgumentNullException(nameof(entities)),
+                    Status = HttpStatusCode.BadRequest
+                };
+            }
+
+            var entitiesList = entities.ToList();
+
+            if (!entitiesList.Any())
+            {
+                return new BulkIngestResponse
+                {
+                    Success = true,
+                    Status = HttpStatusCode.OK
+                };
+            }
+
+            HttpResponseMessage response = null;
+            string responseContentAsString = null;
+
+            try
+            {
+                var jsonEntityArrayToIngest = _jsonSerializer.Serialize(entitiesList);
+                var buffer = Encoding.UTF8.GetBytes(jsonEntityArrayToIngest);
+                var byteContent = new ByteArrayContent(buffer);
+                byteContent.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+                response = connection.HttpClientConnection
+                    .PostAsync("/ingest/v2", byteContent)
+                    .ConfigureAwait(false)
+                    .GetAwaiter()
+                    .GetResult();
+
+                responseContentAsString = response?.Content
+                    .ReadAsStringAsync()
+                    .ConfigureAwait(false)
+                    .GetAwaiter()
+                    .GetResult();
+
+                if (!string.IsNullOrWhiteSpace(responseContentAsString))
+                {
+                    var bulkResponse = _jsonSerializer.Deserialize<BulkIngestResponse>(responseContentAsString);
+                    if (bulkResponse != null)
+                    {
+                        bulkResponse.Status = response.StatusCode;
+                        bulkResponse.Success = response.IsSuccessStatusCode;
+                        bulkResponse.Content = responseContentAsString;
+                        return bulkResponse;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                return new BulkIngestResponse
+                {
+                    Success = false,
+                    Status = response?.StatusCode ?? HttpStatusCode.BadRequest,
+                    Exception = e,
+                    Content = responseContentAsString
+                };
+            }
+
+            if (response == null)
+            {
+                return new BulkIngestResponse
+                {
+                    Success = false,
+                    Status = HttpStatusCode.BadRequest,
+                    Exception = new Exception("Failed sending bulk ingest data")
+                };
+            }
+
+            return new BulkIngestResponse
+            {
+                Status = response.StatusCode,
+                Success = response.IsSuccessStatusCode,
+                Content = responseContentAsString
+            };
+        }
+
+        public BulkDeleteResponse DeleteBulk(IEnumerable<string> originIds)
+        {
+            return DeleteBulk(originIds, _connection);
+        }
+
+        public BulkDeleteResponse DeleteBulk(IEnumerable<string> originIds, IEnterspeedConnection connection)
+        {
+            if (originIds == null)
+            {
+                return new BulkDeleteResponse
+                {
+                    Success = false,
+                    Exception = new ArgumentNullException(nameof(originIds)),
+                    Status = HttpStatusCode.BadRequest
+                };
+            }
+
+            var request = new BulkDeleteRequest(originIds);
+            return DeleteBulk(request, connection);
+        }
+
+        public BulkDeleteResponse DeleteBulk(BulkDeleteRequest request)
+        {
+            return DeleteBulk(request, _connection);
+        }
+
+        public BulkDeleteResponse DeleteBulk(BulkDeleteRequest request, IEnterspeedConnection connection)
+        {
+            if (request == null)
+            {
+                return new BulkDeleteResponse
+                {
+                    Success = false,
+                    Exception = new ArgumentNullException(nameof(request)),
+                    Status = HttpStatusCode.BadRequest
+                };
+            }
+
+            if (request.OriginIds == null || !request.OriginIds.Any())
+            {
+                return new BulkDeleteResponse
+                {
+                    Success = true,
+                    Status = HttpStatusCode.OK
+                };
+            }
+
+            HttpResponseMessage response = null;
+            string responseContentAsString = null;
+
+            try
+            {
+                var jsonRequestBody = _jsonSerializer.Serialize(request);
+                var httpRequest = new HttpRequestMessage(HttpMethod.Delete, "/ingest/v2")
+                {
+                    Content = new StringContent(jsonRequestBody, Encoding.UTF8, "application/json")
+                };
+
+                response = connection.HttpClientConnection
+                    .SendAsync(httpRequest)
+                    .ConfigureAwait(false)
+                    .GetAwaiter()
+                    .GetResult();
+
+                responseContentAsString = response?.Content
+                    .ReadAsStringAsync()
+                    .ConfigureAwait(false)
+                    .GetAwaiter()
+                    .GetResult();
+
+                if (!string.IsNullOrWhiteSpace(responseContentAsString))
+                {
+                    var bulkDeleteResponse = _jsonSerializer.Deserialize<BulkDeleteResponse>(responseContentAsString);
+                    if (bulkDeleteResponse != null)
+                    {
+                        bulkDeleteResponse.Status = response.StatusCode;
+                        bulkDeleteResponse.Success = response.IsSuccessStatusCode;
+                        bulkDeleteResponse.Content = responseContentAsString;
+                        return bulkDeleteResponse;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                return new BulkDeleteResponse
+                {
+                    Success = false,
+                    Status = response?.StatusCode ?? HttpStatusCode.BadRequest,
+                    Exception = e,
+                    Content = responseContentAsString
+                };
+            }
+
+            if (response == null)
+            {
+                return new BulkDeleteResponse
+                {
+                    Success = false,
+                    Status = HttpStatusCode.BadRequest,
+                    Exception = new Exception("Failed sending bulk delete data")
+                };
+            }
+
+            return new BulkDeleteResponse
+            {
+                Status = response.StatusCode,
+                Success = response.IsSuccessStatusCode,
+                Content = responseContentAsString
             };
         }
 

--- a/src/Enterspeed.Source.Sdk/Enterspeed.Source.Sdk.csproj
+++ b/src/Enterspeed.Source.Sdk/Enterspeed.Source.Sdk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;netstandard2.0;net6.0;</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net6.0;net9.0;</TargetFrameworks>
     <PackageId>Enterspeed.Source.Sdk</PackageId>
     <Authors>Enterspeed</Authors>
     <Description>.NET SDK for interacting with Enterspeed Ingest API.</Description>
@@ -15,6 +15,11 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[9.0,10.0)" />
+		<PackageReference Include="System.Text.Json" Version="[9.0,10.0)" />
+	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0,10.0)" />

--- a/src/Enterspeed.Source.Sdk/Extensions/BulkConversionExtensions.cs
+++ b/src/Enterspeed.Source.Sdk/Extensions/BulkConversionExtensions.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.Linq;
+using Enterspeed.Source.Sdk.Api.Models;
+using Enterspeed.Source.Sdk.Api.Models.Bulk;
+
+namespace Enterspeed.Source.Sdk.Extensions
+{
+    /// <summary>
+    /// Extension methods for converting between single and bulk entity formats.
+    /// </summary>
+    public static class BulkConversionExtensions
+    {
+        /// <summary>
+        /// Converts an IEnterspeedEntity to a BulkIngestEntity.
+        /// </summary>
+        public static BulkIngestEntity ToBulkIngestEntity(this IEnterspeedEntity entity)
+        {
+            if (entity == null)
+            {
+                return null;
+            }
+
+            // Handle Properties based on its actual type
+            IDictionary<string, object> properties = null;
+            if (entity.Properties != null)
+            {
+                if (entity.Properties is IDictionary<string, object> dict)
+                {
+                    properties = dict;
+                }
+                else
+                {
+                    // For other types, wrap in a container that will be serialized
+                    properties = new Dictionary<string, object>
+                    {
+                        ["data"] = entity.Properties
+                    };
+                }
+            }
+
+            return new BulkIngestEntity
+            {
+                OriginId = entity.Id,
+                Type = entity.Type,
+                Url = entity.Url,
+                OriginParentId = entity.ParentId,
+                Properties = properties,
+                Redirects = entity.Redirects
+            };
+        }
+
+        /// <summary>
+        /// Converts a collection of IEnterspeedEntity to BulkIngestEntity collection.
+        /// </summary>
+        public static IEnumerable<BulkIngestEntity> ToBulkIngestEntities(
+            this IEnumerable<IEnterspeedEntity> entities)
+        {
+            return entities?.Select(e => e.ToBulkIngestEntity()) ?? Enumerable.Empty<BulkIngestEntity>();
+        }
+
+        /// <summary>
+        /// Converts a generic IEnterspeedEntity to a BulkIngestEntity.
+        /// </summary>
+        public static BulkIngestEntity ToBulkIngestEntity<T>(this IEnterspeedEntity<T> entity)
+        {
+            if (entity == null)
+            {
+                return null;
+            }
+
+            // For generic entities, Properties is of type T
+            IDictionary<string, object> properties = null;
+            if (entity.Properties != null)
+            {
+                if (entity.Properties is IDictionary<string, object> dict)
+                {
+                    properties = dict;
+                }
+                else
+                {
+                    // For other types, wrap in a container for serialization
+                    properties = new Dictionary<string, object>
+                    {
+                        ["data"] = entity.Properties
+                    };
+                }
+            }
+
+            return new BulkIngestEntity
+            {
+                OriginId = entity.Id,
+                Type = entity.Type,
+                Url = entity.Url,
+                OriginParentId = entity.ParentId,
+                Properties = properties,
+                Redirects = entity.Redirects
+            };
+        }
+    }
+}
+

--- a/src/Enterspeed.Source.Sdk/Extensions/BulkResponseExtensions.cs
+++ b/src/Enterspeed.Source.Sdk/Extensions/BulkResponseExtensions.cs
@@ -1,0 +1,123 @@
+using System.Linq;
+using System.Text;
+using Enterspeed.Source.Sdk.Domain.Connection;
+
+namespace Enterspeed.Source.Sdk.Extensions
+{
+    /// <summary>
+    /// Extension methods for working with bulk operation responses.
+    /// </summary>
+    public static class BulkResponseExtensions
+    {
+        /// <summary>
+        /// Gets a human-readable summary of the bulk ingest response.
+        /// </summary>
+        public static string GetSummary(this BulkIngestResponse response)
+        {
+            if (response == null)
+            {
+                return "No response";
+            }
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"Success: {response.Success}");
+            sb.AppendLine($"Changed: {response.ChangedSourceEntities.Count}");
+            sb.AppendLine($"Unchanged: {response.UnchangedSourceEntities.Count}");
+            sb.AppendLine($"Errors: {response.ErrorCount}");
+
+            if (response.IsFullSuccess)
+            {
+                sb.AppendLine("Result: Full Success");
+            }
+            else if (response.IsPartialSuccess)
+            {
+                sb.AppendLine("Result: Partial Success");
+            }
+            else if (response.IsFullFailure)
+            {
+                sb.AppendLine("Result: Full Failure");
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Gets a human-readable summary of the bulk delete response.
+        /// </summary>
+        public static string GetSummary(this BulkDeleteResponse response)
+        {
+            if (response == null)
+            {
+                return "No response";
+            }
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"Success: {response.Success}");
+            sb.AppendLine($"Deleted: {response.DeletedSourceEntities.Count}");
+            sb.AppendLine($"Not Found: {response.NotFoundSourceEntities.Count}");
+            sb.AppendLine($"Errors: {response.ErrorCount}");
+
+            if (response.IsFullSuccess)
+            {
+                sb.AppendLine("Result: Full Success");
+            }
+            else if (response.IsPartialSuccess)
+            {
+                sb.AppendLine("Result: Partial Success");
+            }
+            else if (response.IsFullFailure)
+            {
+                sb.AppendLine("Result: Full Failure");
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Gets all error messages as a formatted string.
+        /// </summary>
+        public static string GetErrorSummary(this BulkIngestResponse response)
+        {
+            if (response?.Errors == null || !response.Errors.Any())
+            {
+                return "No errors";
+            }
+
+            var sb = new StringBuilder();
+            foreach (var error in response.Errors)
+            {
+                sb.AppendLine($"{error.Key}:");
+                foreach (var message in error.Value)
+                {
+                    sb.AppendLine($"  - {message}");
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Gets all error messages as a formatted string.
+        /// </summary>
+        public static string GetErrorSummary(this BulkDeleteResponse response)
+        {
+            if (response?.Errors == null || !response.Errors.Any())
+            {
+                return "No errors";
+            }
+
+            var sb = new StringBuilder();
+            foreach (var error in response.Errors)
+            {
+                sb.AppendLine($"{error.Key}:");
+                foreach (var message in error.Value)
+                {
+                    sb.AppendLine($"  - {message}");
+                }
+            }
+
+            return sb.ToString();
+        }
+    }
+}
+

--- a/tests/Enterspeed.Source.Sdk.Tests/Domain/Services/EnterspeedIngestServiceBulkTests.cs
+++ b/tests/Enterspeed.Source.Sdk.Tests/Domain/Services/EnterspeedIngestServiceBulkTests.cs
@@ -1,0 +1,695 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using AutoFixture;
+using AutoFixture.AutoNSubstitute;
+using Enterspeed.Source.Sdk.Api.Connection;
+using Enterspeed.Source.Sdk.Api.Models.Bulk;
+using Enterspeed.Source.Sdk.Api.Providers;
+using Enterspeed.Source.Sdk.Api.Services;
+using Enterspeed.Source.Sdk.Configuration;
+using Enterspeed.Source.Sdk.Domain.Services;
+using Enterspeed.Source.Sdk.Domain.SystemTextJson;
+using Enterspeed.Source.Sdk.Tests.Mock;
+using NSubstitute;
+using Xunit;
+
+namespace Enterspeed.Source.Sdk.Tests.Domain.Services
+{
+    public class EnterspeedIngestServiceBulkTests
+    {
+        public class BulkTestFixture : Fixture
+        {
+            public IEnterspeedConnection Connection { get; set; }
+            public IEnterspeedConfigurationProvider ConfigurationProvider { get; set; }
+
+            public BulkTestFixture()
+            {
+                Customize(new AutoNSubstituteCustomization());
+                Connection = this.Freeze<IEnterspeedConnection>();
+                ConfigurationProvider = this.Freeze<IEnterspeedConfigurationProvider>();
+
+                this.Register<IJsonSerializer>(() => new SystemTextJsonSerializer());
+            }
+        }
+
+        public class SaveBulk
+        {
+            [Fact]
+            public void WithNullEntities_ReturnsFailureResponse()
+            {
+                // Arrange
+                var fixture = new BulkTestFixture();
+                fixture.ConfigurationProvider
+                    .Configuration
+                    .Returns(new EnterspeedConfiguration());
+
+                var sut = fixture.Create<EnterspeedIngestService>();
+
+                // Act
+                var response = sut.SaveBulk(null);
+
+                // Assert
+                Assert.False(response.Success);
+                Assert.NotNull(response.Exception);
+                Assert.IsType<ArgumentNullException>(response.Exception);
+            }
+
+            [Fact]
+            public void WithEmptyList_ReturnsSuccessResponse()
+            {
+                // Arrange
+                var fixture = new BulkTestFixture();
+                fixture.ConfigurationProvider
+                    .Configuration
+                    .Returns(new EnterspeedConfiguration());
+
+                var entities = new List<BulkIngestEntity>();
+                var sut = fixture.Create<EnterspeedIngestService>();
+
+                // Act
+                var response = sut.SaveBulk(entities);
+
+                // Assert
+                Assert.True(response.Success);
+                Assert.Equal(HttpStatusCode.OK, response.Status);
+                Assert.Empty(response.ChangedSourceEntities);
+                Assert.Empty(response.UnchangedSourceEntities);
+                Assert.Empty(response.Errors);
+            }
+
+            [Fact]
+            public void WithValidEntities_AllChanged_ReturnsFullSuccess()
+            {
+                // Arrange
+                var fixture = new BulkTestFixture();
+
+                var responseContent = @"{
+                    ""changedSourceEntities"": [""product-1"", ""product-2""],
+                    ""unchangedSourceEntities"": [],
+                    ""errors"": {}
+                }";
+
+                var mockMessageHandler = new MockHttpMessageHandler(
+                    responseContent, HttpStatusCode.OK);
+
+                fixture.Connection
+                    .HttpClientConnection
+                    .Returns(
+                        new HttpClient(mockMessageHandler)
+                        {
+                            BaseAddress = new Uri("https://example.com/")
+                        });
+
+                fixture.ConfigurationProvider
+                    .Configuration
+                    .Returns(new EnterspeedConfiguration());
+
+                var entities = new List<BulkIngestEntity>
+                {
+                    new BulkIngestEntity("product-1", "product", new Dictionary<string, object>
+                    {
+                        ["name"] = "Product 1",
+                        ["price"] = 99.99
+                    }),
+                    new BulkIngestEntity("product-2", "product", new Dictionary<string, object>
+                    {
+                        ["name"] = "Product 2",
+                        ["price"] = 149.99
+                    })
+                };
+
+                var sut = fixture.Create<EnterspeedIngestService>();
+
+                // Act
+                var response = sut.SaveBulk(entities);
+
+                // Assert
+                Assert.True(response.Success);
+                Assert.True(response.IsFullSuccess);
+                Assert.False(response.IsPartialSuccess);
+                Assert.False(response.IsFullFailure);
+                Assert.Equal(2, response.ChangedSourceEntities.Count);
+                Assert.Contains("product-1", response.ChangedSourceEntities);
+                Assert.Contains("product-2", response.ChangedSourceEntities);
+                Assert.Empty(response.UnchangedSourceEntities);
+                Assert.Empty(response.Errors);
+                Assert.Equal(2, response.SuccessCount);
+                Assert.Equal(0, response.ErrorCount);
+            }
+
+            [Fact]
+            public void WithValidEntities_SomeUnchanged_ReturnsFullSuccess()
+            {
+                // Arrange
+                var fixture = new BulkTestFixture();
+
+                var responseContent = @"{
+                    ""changedSourceEntities"": [""product-1""],
+                    ""unchangedSourceEntities"": [""product-2""],
+                    ""errors"": {}
+                }";
+
+                var mockMessageHandler = new MockHttpMessageHandler(
+                    responseContent, HttpStatusCode.OK);
+
+                fixture.Connection
+                    .HttpClientConnection
+                    .Returns(
+                        new HttpClient(mockMessageHandler)
+                        {
+                            BaseAddress = new Uri("https://example.com/")
+                        });
+
+                fixture.ConfigurationProvider
+                    .Configuration
+                    .Returns(new EnterspeedConfiguration());
+
+                var entities = new List<BulkIngestEntity>
+                {
+                    new BulkIngestEntity("product-1", "product", new Dictionary<string, object>()),
+                    new BulkIngestEntity("product-2", "product", new Dictionary<string, object>())
+                };
+
+                var sut = fixture.Create<EnterspeedIngestService>();
+
+                // Act
+                var response = sut.SaveBulk(entities);
+
+                // Assert
+                Assert.True(response.Success);
+                Assert.True(response.IsFullSuccess);
+                Assert.Single(response.ChangedSourceEntities);
+                Assert.Single(response.UnchangedSourceEntities);
+                Assert.Empty(response.Errors);
+                Assert.Equal(2, response.SuccessCount);
+            }
+
+            [Fact]
+            public void WithPartialFailure_ReturnsPartialSuccess()
+            {
+                // Arrange
+                var fixture = new BulkTestFixture();
+
+                var responseContent = @"{
+                    ""changedSourceEntities"": [""product-1""],
+                    ""unchangedSourceEntities"": [],
+                    ""errors"": {
+                        ""product-2"": [""Type is required and must not be empty or whitespace""],
+                        ""entities[2]"": [""OriginId is required and must not be empty or whitespace""]
+                    }
+                }";
+
+                var mockMessageHandler = new MockHttpMessageHandler(
+                    responseContent, HttpStatusCode.OK);
+
+                fixture.Connection
+                    .HttpClientConnection
+                    .Returns(
+                        new HttpClient(mockMessageHandler)
+                        {
+                            BaseAddress = new Uri("https://example.com/")
+                        });
+
+                fixture.ConfigurationProvider
+                    .Configuration
+                    .Returns(new EnterspeedConfiguration());
+
+                var entities = new List<BulkIngestEntity>
+                {
+                    new BulkIngestEntity("product-1", "product", new Dictionary<string, object>()),
+                    new BulkIngestEntity("product-2", null, new Dictionary<string, object>()),
+                    new BulkIngestEntity(null, "product", new Dictionary<string, object>())
+                };
+
+                var sut = fixture.Create<EnterspeedIngestService>();
+
+                // Act
+                var response = sut.SaveBulk(entities);
+
+                // Assert
+                Assert.True(response.Success);
+                Assert.False(response.IsFullSuccess);
+                Assert.True(response.IsPartialSuccess);
+                Assert.False(response.IsFullFailure);
+                Assert.Single(response.ChangedSourceEntities);
+                Assert.Equal(2, response.Errors.Count);
+                Assert.True(response.Errors.ContainsKey("product-2"));
+                Assert.True(response.Errors.ContainsKey("entities[2]"));
+                Assert.Equal(1, response.SuccessCount);
+                Assert.Equal(2, response.ErrorCount);
+                Assert.Contains("product-2", response.FailedOriginIds);
+                Assert.Contains("entities[2]", response.FailedOriginIds);
+            }
+
+            [Fact]
+            public void WithAllFailures_ReturnsFullFailure()
+            {
+                // Arrange
+                var fixture = new BulkTestFixture();
+
+                var responseContent = @"{
+                    ""changedSourceEntities"": [],
+                    ""unchangedSourceEntities"": [],
+                    ""errors"": {
+                        ""product-1"": [""Type is required""],
+                        ""product-2"": [""OriginId is required""]
+                    }
+                }";
+
+                var mockMessageHandler = new MockHttpMessageHandler(
+                    responseContent, HttpStatusCode.OK);
+
+                fixture.Connection
+                    .HttpClientConnection
+                    .Returns(
+                        new HttpClient(mockMessageHandler)
+                        {
+                            BaseAddress = new Uri("https://example.com/")
+                        });
+
+                fixture.ConfigurationProvider
+                    .Configuration
+                    .Returns(new EnterspeedConfiguration());
+
+                var entities = new List<BulkIngestEntity>
+                {
+                    new BulkIngestEntity("product-1", null, new Dictionary<string, object>()),
+                    new BulkIngestEntity(null, "product", new Dictionary<string, object>())
+                };
+
+                var sut = fixture.Create<EnterspeedIngestService>();
+
+                // Act
+                var response = sut.SaveBulk(entities);
+
+                // Assert
+                Assert.True(response.Success);
+                Assert.False(response.IsFullSuccess);
+                Assert.False(response.IsPartialSuccess);
+                Assert.True(response.IsFullFailure);
+                Assert.Empty(response.ChangedSourceEntities);
+                Assert.Empty(response.UnchangedSourceEntities);
+                Assert.Equal(2, response.Errors.Count);
+                Assert.Equal(0, response.SuccessCount);
+                Assert.Equal(2, response.ErrorCount);
+            }
+
+            [Fact]
+            public void GetErrorsForOriginId_ReturnsCorrectErrors()
+            {
+                // Arrange
+                var fixture = new BulkTestFixture();
+
+                var responseContent = @"{
+                    ""changedSourceEntities"": [],
+                    ""unchangedSourceEntities"": [],
+                    ""errors"": {
+                        ""product-1"": [""Error 1"", ""Error 2""],
+                        ""product-2"": [""Error 3""]
+                    }
+                }";
+
+                var mockMessageHandler = new MockHttpMessageHandler(
+                    responseContent, HttpStatusCode.OK);
+
+                fixture.Connection
+                    .HttpClientConnection
+                    .Returns(
+                        new HttpClient(mockMessageHandler)
+                        {
+                            BaseAddress = new Uri("https://example.com/")
+                        });
+
+                fixture.ConfigurationProvider
+                    .Configuration
+                    .Returns(new EnterspeedConfiguration());
+
+                var entities = new List<BulkIngestEntity>
+                {
+                    new BulkIngestEntity("product-1", "product", new Dictionary<string, object>())
+                };
+
+                var sut = fixture.Create<EnterspeedIngestService>();
+
+                // Act
+                var response = sut.SaveBulk(entities);
+                var errors = response.GetErrorsForOriginId("product-1").ToList();
+
+                // Assert
+                Assert.Equal(2, errors.Count);
+                Assert.Contains("Error 1", errors);
+                Assert.Contains("Error 2", errors);
+            }
+
+            [Fact]
+            public void WithHttpException_ReturnsFailureResponse()
+            {
+                // Arrange
+                var fixture = new BulkTestFixture();
+
+                var mockMessageHandler = new MockHttpMessageHandler(HttpStatusCode.BadRequest, throwException: true);
+
+                fixture.Connection
+                    .HttpClientConnection
+                    .Returns(
+                        new HttpClient(mockMessageHandler)
+                        {
+                            BaseAddress = new Uri("https://example.com/")
+                        });
+
+                fixture.ConfigurationProvider
+                    .Configuration
+                    .Returns(new EnterspeedConfiguration());
+
+                var entities = new List<BulkIngestEntity>
+                {
+                    new BulkIngestEntity("product-1", "product", new Dictionary<string, object>())
+                };
+
+                var sut = fixture.Create<EnterspeedIngestService>();
+
+                // Act
+                var response = sut.SaveBulk(entities);
+
+                // Assert
+                Assert.False(response.Success);
+                Assert.NotNull(response.Exception);
+            }
+
+            [Fact]
+            public void WithFeatureNotEnabled_ReturnsErrorResponse()
+            {
+                // Arrange
+                var fixture = new BulkTestFixture();
+
+                var responseContent = @"{
+                    ""error"": ""Bulk ingest not available for this tenant""
+                }";
+
+                var mockMessageHandler = new MockHttpMessageHandler(
+                    responseContent, HttpStatusCode.BadRequest);
+
+                fixture.Connection
+                    .HttpClientConnection
+                    .Returns(
+                        new HttpClient(mockMessageHandler)
+                        {
+                            BaseAddress = new Uri("https://example.com/")
+                        });
+
+                fixture.ConfigurationProvider
+                    .Configuration
+                    .Returns(new EnterspeedConfiguration());
+
+                var entities = new List<BulkIngestEntity>
+                {
+                    new BulkIngestEntity("product-1", "product", new Dictionary<string, object>())
+                };
+
+                var sut = fixture.Create<EnterspeedIngestService>();
+
+                // Act
+                var response = sut.SaveBulk(entities);
+
+                // Assert
+                Assert.False(response.Success);
+                Assert.Equal(HttpStatusCode.BadRequest, response.Status);
+            }
+        }
+
+        public class DeleteBulk
+        {
+            [Fact]
+            public void WithNullOriginIds_ReturnsFailureResponse()
+            {
+                // Arrange
+                var fixture = new BulkTestFixture();
+                fixture.ConfigurationProvider
+                    .Configuration
+                    .Returns(new EnterspeedConfiguration());
+
+                var sut = fixture.Create<EnterspeedIngestService>();
+
+                // Act
+                var response = sut.DeleteBulk((IEnumerable<string>)null);
+
+                // Assert
+                Assert.False(response.Success);
+                Assert.NotNull(response.Exception);
+                Assert.IsType<ArgumentNullException>(response.Exception);
+            }
+
+            [Fact]
+            public void WithNullRequest_ReturnsFailureResponse()
+            {
+                // Arrange
+                var fixture = new BulkTestFixture();
+                fixture.ConfigurationProvider
+                    .Configuration
+                    .Returns(new EnterspeedConfiguration());
+
+                var sut = fixture.Create<EnterspeedIngestService>();
+
+                // Act
+                var response = sut.DeleteBulk((BulkDeleteRequest)null);
+
+                // Assert
+                Assert.False(response.Success);
+                Assert.NotNull(response.Exception);
+                Assert.IsType<ArgumentNullException>(response.Exception);
+            }
+
+            [Fact]
+            public void WithEmptyList_ReturnsSuccessResponse()
+            {
+                // Arrange
+                var fixture = new BulkTestFixture();
+                fixture.ConfigurationProvider
+                    .Configuration
+                    .Returns(new EnterspeedConfiguration());
+
+                var originIds = new List<string>();
+                var sut = fixture.Create<EnterspeedIngestService>();
+
+                // Act
+                var response = sut.DeleteBulk(originIds);
+
+                // Assert
+                Assert.True(response.Success);
+                Assert.Equal(HttpStatusCode.OK, response.Status);
+                Assert.Empty(response.DeletedSourceEntities);
+                Assert.Empty(response.NotFoundSourceEntities);
+                Assert.Empty(response.Errors);
+            }
+
+            [Fact]
+            public void WithValidIds_AllDeleted_ReturnsFullSuccess()
+            {
+                // Arrange
+                var fixture = new BulkTestFixture();
+
+                var responseContent = @"{
+                    ""deletedSourceEntities"": [""product-1"", ""product-2""],
+                    ""notFoundSourceEntities"": [],
+                    ""errors"": {}
+                }";
+
+                var mockMessageHandler = new MockHttpMessageHandler(
+                    responseContent, HttpStatusCode.OK);
+
+                fixture.Connection
+                    .HttpClientConnection
+                    .Returns(
+                        new HttpClient(mockMessageHandler)
+                        {
+                            BaseAddress = new Uri("https://example.com/")
+                        });
+
+                fixture.ConfigurationProvider
+                    .Configuration
+                    .Returns(new EnterspeedConfiguration());
+
+                var originIds = new[] { "product-1", "product-2" };
+                var sut = fixture.Create<EnterspeedIngestService>();
+
+                // Act
+                var response = sut.DeleteBulk(originIds);
+
+                // Assert
+                Assert.True(response.Success);
+                Assert.True(response.IsFullSuccess);
+                Assert.Equal(2, response.DeletedSourceEntities.Count);
+                Assert.Contains("product-1", response.DeletedSourceEntities);
+                Assert.Contains("product-2", response.DeletedSourceEntities);
+                Assert.Empty(response.NotFoundSourceEntities);
+                Assert.Empty(response.Errors);
+                Assert.Equal(2, response.SuccessCount);
+                Assert.Equal(0, response.ErrorCount);
+            }
+
+            [Fact]
+            public void WithSomeNotFound_ReturnsFullSuccess()
+            {
+                // Arrange
+                var fixture = new BulkTestFixture();
+
+                var responseContent = @"{
+                    ""deletedSourceEntities"": [""product-1""],
+                    ""notFoundSourceEntities"": [""product-2"", ""product-3""],
+                    ""errors"": {}
+                }";
+
+                var mockMessageHandler = new MockHttpMessageHandler(
+                    responseContent, HttpStatusCode.OK);
+
+                fixture.Connection
+                    .HttpClientConnection
+                    .Returns(
+                        new HttpClient(mockMessageHandler)
+                        {
+                            BaseAddress = new Uri("https://example.com/")
+                        });
+
+                fixture.ConfigurationProvider
+                    .Configuration
+                    .Returns(new EnterspeedConfiguration());
+
+                var originIds = new[] { "product-1", "product-2", "product-3" };
+                var sut = fixture.Create<EnterspeedIngestService>();
+
+                // Act
+                var response = sut.DeleteBulk(originIds);
+
+                // Assert
+                Assert.True(response.Success);
+                Assert.True(response.IsFullSuccess);
+                Assert.False(response.IsPartialSuccess);
+                Assert.Single(response.DeletedSourceEntities);
+                Assert.Equal(2, response.NotFoundSourceEntities.Count);
+                Assert.Empty(response.Errors);
+                Assert.Equal(3, response.SuccessCount); // NotFound is success
+            }
+
+            [Fact]
+            public void WithPartialFailure_ReturnsPartialSuccess()
+            {
+                // Arrange
+                var fixture = new BulkTestFixture();
+
+                var responseContent = @"{
+                    ""deletedSourceEntities"": [""product-1""],
+                    ""notFoundSourceEntities"": [""product-2""],
+                    ""errors"": {
+                        ""originIds[2]"": [""OriginId cannot be empty at position 2""],
+                        ""null"": [""OriginId cannot be null""]
+                    }
+                }";
+
+                var mockMessageHandler = new MockHttpMessageHandler(
+                    responseContent, HttpStatusCode.OK);
+
+                fixture.Connection
+                    .HttpClientConnection
+                    .Returns(
+                        new HttpClient(mockMessageHandler)
+                        {
+                            BaseAddress = new Uri("https://example.com/")
+                        });
+
+                fixture.ConfigurationProvider
+                    .Configuration
+                    .Returns(new EnterspeedConfiguration());
+
+                var originIds = new[] { "product-1", "product-2" };
+                var sut = fixture.Create<EnterspeedIngestService>();
+
+                // Act
+                var response = sut.DeleteBulk(originIds);
+
+                // Assert
+                Assert.True(response.Success);
+                Assert.False(response.IsFullSuccess);
+                Assert.True(response.IsPartialSuccess);
+                Assert.Single(response.DeletedSourceEntities);
+                Assert.Single(response.NotFoundSourceEntities);
+                Assert.Equal(2, response.Errors.Count);
+                Assert.Equal(2, response.SuccessCount);
+                Assert.Equal(2, response.ErrorCount);
+            }
+
+            [Fact]
+            public void WithBulkDeleteRequest_WorksCorrectly()
+            {
+                // Arrange
+                var fixture = new BulkTestFixture();
+
+                var responseContent = @"{
+                    ""deletedSourceEntities"": [""product-1""],
+                    ""notFoundSourceEntities"": [],
+                    ""errors"": {}
+                }";
+
+                var mockMessageHandler = new MockHttpMessageHandler(
+                    responseContent, HttpStatusCode.OK);
+
+                fixture.Connection
+                    .HttpClientConnection
+                    .Returns(
+                        new HttpClient(mockMessageHandler)
+                        {
+                            BaseAddress = new Uri("https://example.com/")
+                        });
+
+                fixture.ConfigurationProvider
+                    .Configuration
+                    .Returns(new EnterspeedConfiguration());
+
+                var request = new BulkDeleteRequest(new[] { "product-1" });
+                var sut = fixture.Create<EnterspeedIngestService>();
+
+                // Act
+                var response = sut.DeleteBulk(request);
+
+                // Assert
+                Assert.True(response.Success);
+                Assert.True(response.IsFullSuccess);
+                Assert.Single(response.DeletedSourceEntities);
+            }
+
+            [Fact]
+            public void WithHttpException_ReturnsFailureResponse()
+            {
+                // Arrange
+                var fixture = new BulkTestFixture();
+
+                var mockMessageHandler = new MockHttpMessageHandler(HttpStatusCode.BadRequest, throwException: true);
+
+                fixture.Connection
+                    .HttpClientConnection
+                    .Returns(
+                        new HttpClient(mockMessageHandler)
+                        {
+                            BaseAddress = new Uri("https://example.com/")
+                        });
+
+                fixture.ConfigurationProvider
+                    .Configuration
+                    .Returns(new EnterspeedConfiguration());
+
+                var originIds = new[] { "product-1" };
+                var sut = fixture.Create<EnterspeedIngestService>();
+
+                // Act
+                var response = sut.DeleteBulk(originIds);
+
+                // Assert
+                Assert.False(response.Success);
+                Assert.NotNull(response.Exception);
+            }
+        }
+    }
+}
+

--- a/tests/Enterspeed.Source.Sdk.Tests/Extensions/BulkConversionExtensionsTests.cs
+++ b/tests/Enterspeed.Source.Sdk.Tests/Extensions/BulkConversionExtensionsTests.cs
@@ -1,0 +1,243 @@
+using System.Collections.Generic;
+using System.Linq;
+using Enterspeed.Source.Sdk.Api.Models;
+using Enterspeed.Source.Sdk.Api.Models.Bulk;
+using Enterspeed.Source.Sdk.Extensions;
+using Xunit;
+
+namespace Enterspeed.Source.Sdk.Tests.Extensions
+{
+    public class BulkConversionExtensionsTests
+    {
+        public class ToBulkIngestEntity
+        {
+            [Fact]
+            public void WithNullEntity_ReturnsNull()
+            {
+                // Arrange
+                IEnterspeedEntity entity = null;
+
+                // Act
+                var result = entity.ToBulkIngestEntity();
+
+                // Assert
+                Assert.Null(result);
+            }
+
+            [Fact]
+            public void WithValidEntity_ConvertsCorrectly()
+            {
+                // Arrange
+                var properties = new Dictionary<string, object>
+                {
+                    ["name"] = "Test Product",
+                    ["price"] = 99.99
+                };
+
+                var entity = new EnterspeedEntity("product-123", "product", properties)
+                {
+                    Url = "/products/test",
+                    ParentId = "category-456",
+                    Redirects = new[] { "/old-url" }
+                };
+
+                // Act
+                var result = entity.ToBulkIngestEntity();
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.Equal("product-123", result.OriginId);
+                Assert.Equal("product", result.Type);
+                Assert.Equal("/products/test", result.Url);
+                Assert.Equal("category-456", result.OriginParentId);
+                Assert.NotNull(result.Redirects);
+                Assert.Single(result.Redirects);
+                Assert.Equal("/old-url", result.Redirects[0]);
+                Assert.NotNull(result.Properties);
+            }
+
+            [Fact]
+            public void WithDictionaryProperties_MapsDirectly()
+            {
+                // Arrange
+                var properties = new Dictionary<string, object>
+                {
+                    ["name"] = "Test",
+                    ["count"] = 42
+                };
+
+                var entity = new EnterspeedEntity("test-1", "test", properties);
+
+                // Act
+                var result = entity.ToBulkIngestEntity();
+
+                // Assert
+                Assert.Same(properties, result.Properties);
+                Assert.Equal("Test", result.Properties["name"]);
+                Assert.Equal(42, result.Properties["count"]);
+            }
+
+            [Fact]
+            public void WithNullProperties_HandlesGracefully()
+            {
+                // Arrange
+                var entity = new EnterspeedEntity("test-1", "test", null);
+
+                // Act
+                var result = entity.ToBulkIngestEntity();
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.Null(result.Properties);
+            }
+
+            [Fact]
+            public void WithNonDictionaryProperties_WrapsInContainer()
+            {
+                // Arrange
+                var customObject = new { Name = "Test", Count = 42 };
+                var entity = new EnterspeedEntity("test-1", "test", customObject);
+
+                // Act
+                var result = entity.ToBulkIngestEntity();
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.NotNull(result.Properties);
+                Assert.True(result.Properties.ContainsKey("data"));
+                Assert.Same(customObject, result.Properties["data"]);
+            }
+        }
+
+        public class ToBulkIngestEntityGeneric
+        {
+            [Fact]
+            public void WithNullEntity_ReturnsNull()
+            {
+                // Arrange
+                IEnterspeedEntity<Dictionary<string, object>> entity = null;
+
+                // Act
+                var result = entity.ToBulkIngestEntity();
+
+                // Assert
+                Assert.Null(result);
+            }
+
+            [Fact]
+            public void WithGenericEntity_ConvertsCorrectly()
+            {
+                // Arrange
+                var properties = new Dictionary<string, object>
+                {
+                    ["name"] = "Test Product"
+                };
+
+                var entity = new EnterspeedEntity<Dictionary<string, object>>("product-123", "product", properties);
+
+                // Act
+                var result = entity.ToBulkIngestEntity();
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.Equal("product-123", result.OriginId);
+                Assert.Equal("product", result.Type);
+                Assert.Same(properties, result.Properties);
+            }
+
+            [Fact]
+            public void WithCustomTypeProperties_WrapsInContainer()
+            {
+                // Arrange
+                var customProps = new { Name = "Test", Price = 99.99 };
+                var entity = new EnterspeedEntity<object>("test-1", "test", customProps);
+
+                // Act
+                var result = entity.ToBulkIngestEntity();
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.NotNull(result.Properties);
+                Assert.True(result.Properties.ContainsKey("data"));
+                Assert.Same(customProps, result.Properties["data"]);
+            }
+        }
+
+        public class ToBulkIngestEntities
+        {
+            [Fact]
+            public void WithNullCollection_ReturnsEmptyEnumerable()
+            {
+                // Arrange
+                IEnumerable<IEnterspeedEntity> entities = null;
+
+                // Act
+                var result = entities.ToBulkIngestEntities();
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.Empty(result);
+            }
+
+            [Fact]
+            public void WithEmptyCollection_ReturnsEmptyEnumerable()
+            {
+                // Arrange
+                var entities = new List<IEnterspeedEntity>();
+
+                // Act
+                var result = entities.ToBulkIngestEntities();
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.Empty(result);
+            }
+
+            [Fact]
+            public void WithMultipleEntities_ConvertsAll()
+            {
+                // Arrange
+                var entities = new List<IEnterspeedEntity>
+                {
+                    new EnterspeedEntity("product-1", "product", new Dictionary<string, object> { ["name"] = "Product 1" }),
+                    new EnterspeedEntity("product-2", "product", new Dictionary<string, object> { ["name"] = "Product 2" }),
+                    new EnterspeedEntity("product-3", "product", new Dictionary<string, object> { ["name"] = "Product 3" })
+                };
+
+                // Act
+                var result = entities.ToBulkIngestEntities().ToList();
+
+                // Assert
+                Assert.Equal(3, result.Count);
+                Assert.Equal("product-1", result[0].OriginId);
+                Assert.Equal("product-2", result[1].OriginId);
+                Assert.Equal("product-3", result[2].OriginId);
+            }
+
+            [Fact]
+            public void WithMixedEntities_ConvertsAllCorrectly()
+            {
+                // Arrange
+                var entities = new List<IEnterspeedEntity>
+                {
+                    new EnterspeedEntity("product-1", "product", new Dictionary<string, object>())
+                    {
+                        Url = "/products/1"
+                    },
+                    new EnterspeedEntity("category-1", "category", new Dictionary<string, object>())
+                };
+
+                // Act
+                var result = entities.ToBulkIngestEntities().ToList();
+
+                // Assert
+                Assert.Equal(2, result.Count);
+                Assert.Equal("product", result[0].Type);
+                Assert.Equal("/products/1", result[0].Url);
+                Assert.Equal("category", result[1].Type);
+                Assert.Null(result[1].Url);
+            }
+        }
+    }
+}
+

--- a/tests/Enterspeed.Source.Sdk.Tests/Extensions/BulkResponseExtensionsTests.cs
+++ b/tests/Enterspeed.Source.Sdk.Tests/Extensions/BulkResponseExtensionsTests.cs
@@ -1,0 +1,327 @@
+using System.Collections.Generic;
+using System.Net;
+using Enterspeed.Source.Sdk.Domain.Connection;
+using Enterspeed.Source.Sdk.Extensions;
+using Xunit;
+
+namespace Enterspeed.Source.Sdk.Tests.Extensions
+{
+    public class BulkResponseExtensionsTests
+    {
+        public class BulkIngestResponseGetSummary
+        {
+            [Fact]
+            public void WithNullResponse_ReturnsNoResponse()
+            {
+                // Arrange
+                BulkIngestResponse response = null;
+
+                // Act
+                var summary = response.GetSummary();
+
+                // Assert
+                Assert.Equal("No response", summary);
+            }
+
+            [Fact]
+            public void WithFullSuccess_ReturnsCorrectSummary()
+            {
+                // Arrange
+                var response = new BulkIngestResponse
+                {
+                    Success = true,
+                    ChangedSourceEntities = new List<string> { "id1", "id2" },
+                    UnchangedSourceEntities = new List<string> { "id3" },
+                    Errors = new Dictionary<string, List<string>>()
+                };
+
+                // Act
+                var summary = response.GetSummary();
+
+                // Assert
+                Assert.Contains("Success: True", summary);
+                Assert.Contains("Changed: 2", summary);
+                Assert.Contains("Unchanged: 1", summary);
+                Assert.Contains("Errors: 0", summary);
+                Assert.Contains("Result: Full Success", summary);
+            }
+
+            [Fact]
+            public void WithPartialSuccess_ReturnsCorrectSummary()
+            {
+                // Arrange
+                var response = new BulkIngestResponse
+                {
+                    Success = true,
+                    ChangedSourceEntities = new List<string> { "id1" },
+                    UnchangedSourceEntities = new List<string>(),
+                    Errors = new Dictionary<string, List<string>>
+                    {
+                        ["id2"] = new List<string> { "Error" }
+                    }
+                };
+
+                // Act
+                var summary = response.GetSummary();
+
+                // Assert
+                Assert.Contains("Success: True", summary);
+                Assert.Contains("Changed: 1", summary);
+                Assert.Contains("Unchanged: 0", summary);
+                Assert.Contains("Errors: 1", summary);
+                Assert.Contains("Result: Partial Success", summary);
+            }
+
+            [Fact]
+            public void WithFullFailure_ReturnsCorrectSummary()
+            {
+                // Arrange
+                var response = new BulkIngestResponse
+                {
+                    Success = true,
+                    ChangedSourceEntities = new List<string>(),
+                    UnchangedSourceEntities = new List<string>(),
+                    Errors = new Dictionary<string, List<string>>
+                    {
+                        ["id1"] = new List<string> { "Error 1" },
+                        ["id2"] = new List<string> { "Error 2" }
+                    }
+                };
+
+                // Act
+                var summary = response.GetSummary();
+
+                // Assert
+                Assert.Contains("Success: True", summary);
+                Assert.Contains("Changed: 0", summary);
+                Assert.Contains("Unchanged: 0", summary);
+                Assert.Contains("Errors: 2", summary);
+                Assert.Contains("Result: Full Failure", summary);
+            }
+        }
+
+        public class BulkDeleteResponseGetSummary
+        {
+            [Fact]
+            public void WithNullResponse_ReturnsNoResponse()
+            {
+                // Arrange
+                BulkDeleteResponse response = null;
+
+                // Act
+                var summary = response.GetSummary();
+
+                // Assert
+                Assert.Equal("No response", summary);
+            }
+
+            [Fact]
+            public void WithFullSuccess_ReturnsCorrectSummary()
+            {
+                // Arrange
+                var response = new BulkDeleteResponse
+                {
+                    Success = true,
+                    DeletedSourceEntities = new List<string> { "id1", "id2" },
+                    NotFoundSourceEntities = new List<string> { "id3" },
+                    Errors = new Dictionary<string, List<string>>()
+                };
+
+                // Act
+                var summary = response.GetSummary();
+
+                // Assert
+                Assert.Contains("Success: True", summary);
+                Assert.Contains("Deleted: 2", summary);
+                Assert.Contains("Not Found: 1", summary);
+                Assert.Contains("Errors: 0", summary);
+                Assert.Contains("Result: Full Success", summary);
+            }
+
+            [Fact]
+            public void WithPartialSuccess_ReturnsCorrectSummary()
+            {
+                // Arrange
+                var response = new BulkDeleteResponse
+                {
+                    Success = true,
+                    DeletedSourceEntities = new List<string> { "id1" },
+                    NotFoundSourceEntities = new List<string>(),
+                    Errors = new Dictionary<string, List<string>>
+                    {
+                        ["id2"] = new List<string> { "Error" }
+                    }
+                };
+
+                // Act
+                var summary = response.GetSummary();
+
+                // Assert
+                Assert.Contains("Success: True", summary);
+                Assert.Contains("Deleted: 1", summary);
+                Assert.Contains("Not Found: 0", summary);
+                Assert.Contains("Errors: 1", summary);
+                Assert.Contains("Result: Partial Success", summary);
+            }
+        }
+
+        public class BulkIngestResponseGetErrorSummary
+        {
+            [Fact]
+            public void WithNullResponse_ReturnsNoErrors()
+            {
+                // Arrange
+                BulkIngestResponse response = null;
+
+                // Act
+                var errorSummary = response.GetErrorSummary();
+
+                // Assert
+                Assert.Equal("No errors", errorSummary);
+            }
+
+            [Fact]
+            public void WithNoErrors_ReturnsNoErrors()
+            {
+                // Arrange
+                var response = new BulkIngestResponse
+                {
+                    Errors = new Dictionary<string, List<string>>()
+                };
+
+                // Act
+                var errorSummary = response.GetErrorSummary();
+
+                // Assert
+                Assert.Equal("No errors", errorSummary);
+            }
+
+            [Fact]
+            public void WithSingleError_ReturnsFormattedError()
+            {
+                // Arrange
+                var response = new BulkIngestResponse
+                {
+                    Errors = new Dictionary<string, List<string>>
+                    {
+                        ["product-123"] = new List<string> { "Type is required" }
+                    }
+                };
+
+                // Act
+                var errorSummary = response.GetErrorSummary();
+
+                // Assert
+                Assert.Contains("product-123:", errorSummary);
+                Assert.Contains("- Type is required", errorSummary);
+            }
+
+            [Fact]
+            public void WithMultipleErrorsPerEntity_ReturnsAllErrors()
+            {
+                // Arrange
+                var response = new BulkIngestResponse
+                {
+                    Errors = new Dictionary<string, List<string>>
+                    {
+                        ["product-123"] = new List<string> 
+                        { 
+                            "Type is required",
+                            "OriginId is required"
+                        }
+                    }
+                };
+
+                // Act
+                var errorSummary = response.GetErrorSummary();
+
+                // Assert
+                Assert.Contains("product-123:", errorSummary);
+                Assert.Contains("- Type is required", errorSummary);
+                Assert.Contains("- OriginId is required", errorSummary);
+            }
+
+            [Fact]
+            public void WithMultipleEntities_ReturnsAllEntityErrors()
+            {
+                // Arrange
+                var response = new BulkIngestResponse
+                {
+                    Errors = new Dictionary<string, List<string>>
+                    {
+                        ["product-123"] = new List<string> { "Error 1" },
+                        ["product-456"] = new List<string> { "Error 2" },
+                        ["entities[5]"] = new List<string> { "Error 3" }
+                    }
+                };
+
+                // Act
+                var errorSummary = response.GetErrorSummary();
+
+                // Assert
+                Assert.Contains("product-123:", errorSummary);
+                Assert.Contains("product-456:", errorSummary);
+                Assert.Contains("entities[5]:", errorSummary);
+                Assert.Contains("- Error 1", errorSummary);
+                Assert.Contains("- Error 2", errorSummary);
+                Assert.Contains("- Error 3", errorSummary);
+            }
+        }
+
+        public class BulkDeleteResponseGetErrorSummary
+        {
+            [Fact]
+            public void WithNullResponse_ReturnsNoErrors()
+            {
+                // Arrange
+                BulkDeleteResponse response = null;
+
+                // Act
+                var errorSummary = response.GetErrorSummary();
+
+                // Assert
+                Assert.Equal("No errors", errorSummary);
+            }
+
+            [Fact]
+            public void WithNoErrors_ReturnsNoErrors()
+            {
+                // Arrange
+                var response = new BulkDeleteResponse
+                {
+                    Errors = new Dictionary<string, List<string>>()
+                };
+
+                // Act
+                var errorSummary = response.GetErrorSummary();
+
+                // Assert
+                Assert.Equal("No errors", errorSummary);
+            }
+
+            [Fact]
+            public void WithErrors_ReturnsFormattedErrors()
+            {
+                // Arrange
+                var response = new BulkDeleteResponse
+                {
+                    Errors = new Dictionary<string, List<string>>
+                    {
+                        ["originIds[2]"] = new List<string> { "OriginId cannot be empty" },
+                        ["null"] = new List<string> { "OriginId cannot be null" }
+                    }
+                };
+
+                // Act
+                var errorSummary = response.GetErrorSummary();
+
+                // Assert
+                Assert.Contains("originIds[2]:", errorSummary);
+                Assert.Contains("null:", errorSummary);
+                Assert.Contains("- OriginId cannot be empty", errorSummary);
+                Assert.Contains("- OriginId cannot be null", errorSummary);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
[Ticket](https://app.shortcut.com/enterspeed/story/8136/add-bulk-ingest-delete-to-ingest-sdk)

This pull request introduces bulk ingest and bulk delete functionality to the SDK, enabling efficient processing of multiple entities in a single HTTP request. These new methods provide significant performance improvements for batch operations, along with comprehensive response models and helper extensions for analyzing results. Bulk operations require a feature flag to be enabled and have configurable limits per tenant.

**Bulk Operations Feature:**
* Added `SaveBulk()` and `DeleteBulk()` methods to `IEnterspeedIngestService` for ingesting and deleting multiple entities in one request, including overloads for custom connections and request models.
* Introduced the `BulkIngestEntity` model for bulk ingest, and the `BulkDeleteRequest` model for bulk delete operations. [[1]](diffhunk://#diff-4a7f2adbca07dcf6282a46b17cf090e4830c9dc460fdc67404591e446f88598bR1-R53) [[2]](diffhunk://#diff-2a518d78e75fdc2326240ca91759dcd667d0478ae25a6b6aed6f4eb6b0f46706R1-R26)

**Bulk Operation Response Models:**
* Added `BulkIngestResponse` and `BulkDeleteResponse` classes, which include helper properties (`IsFullSuccess`, `IsPartialSuccess`, `IsFullFailure`, `SuccessCount`, `ErrorCount`, etc.) and methods for analyzing results and errors per entity. [[1]](diffhunk://#diff-3616d35701c53b4d87d7ef405e94fed69cd8a643cff2225d41b7ed309dfc92efR1-R108) [[2]](diffhunk://#diff-01baac4aa48aa209816023a8b1ee12209711659d02c1ff68ca0ef30b6e616771R1-R110)

**Documentation and Usage:**
* Updated `README.md` with usage examples and important notes for bulk operations, including requirements, limits, and performance improvements.
* Updated `CHANGELOG.md` to document the new bulk operations, performance improvements, and requirements.

**Performance and Requirements:**
* Bulk operations deliver 10-20x performance improvement over sequential single operations and reduce HTTP overhead for batch processing. Bulk operations require the `IsAsyncBulkProcessingEnabled` feature flag and have default limits of 50 entities and 210MB per request, configurable per tenant. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R26) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R74-R144)