### PR TITLE
Update CHANGELOG.md for version 2.0.7 and add support for .NET 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Added support for .NET 10
 
 ### Changed
-- Updated dependency on `Microsoft.Extensions.DependencyInjection.Abstractions` to version 10 for .NET 10 target
-- Updated dependency on `System.Text.Json` to version 10 for .NET 10 target
+- Updated dependency on `Microsoft.Extensions.DependencyInjection.Abstractions` to 10.x (range [10.0,11.0)) for the .NET 10 target and widened version ranges for other target frameworks (.NET 6, .NET 9, .NET Standard 2.0)
+- Updated dependency on `System.Text.Json` to 10.x (range [10.0,11.0)) for the .NET 10 target and widened version ranges for other target frameworks (.NET 6, .NET 9, .NET Standard 2.0)
 
 ## [2.0.6 - 2026-01-21]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [2.0.7 - 2026-02-09]
+### Added
+- Added support for .NET 10
+
+### Changed
+- Updated dependency on `Microsoft.Extensions.DependencyInjection.Abstractions` to version 10 for .NET 10 target
+- Updated dependency on `System.Text.Json` to version 10 for .NET 10 target
+
 ## [2.0.6 - 2026-01-21]
 ### Added
 - Bulk ingest endpoint support for batch ingesting multiple source entities

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ variables:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   majorVersion: 2
   minorVersion: 0
-  patchVersion: 6
+  patchVersion: 7
   version: $[format('{0}.{1}.{2}', variables.majorVersion, variables.minorVersion, variables.patchVersion)]
   ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/master') }}:
     releaseOnNuget: true
@@ -73,6 +73,12 @@ stages:
             inputs:
               packageType: sdk
               version: "9.0.x"
+
+          - task: UseDotNet@2
+            displayName: Install .NET 10.0 SDK
+            inputs:
+              packageType: sdk
+              version: "10.0.x"
 
           # NuGet
           - task: NuGetToolInstaller@1

--- a/src/Enterspeed.Source.Sdk/Domain/SystemTextJson/HttpStatusCodeConverter.cs
+++ b/src/Enterspeed.Source.Sdk/Domain/SystemTextJson/HttpStatusCodeConverter.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0 || NET6_0
+﻿#if NETSTANDARD2_0 || NET6_0_OR_GREATER
 using System;
 using System.Net;
 using System.Text.Json;

--- a/src/Enterspeed.Source.Sdk/Domain/SystemTextJson/SystemTextJsonSerializer.cs
+++ b/src/Enterspeed.Source.Sdk/Domain/SystemTextJson/SystemTextJsonSerializer.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0 || NET6_0
+﻿#if NETSTANDARD2_0 || NET6_0_OR_GREATER
 using System.Text.Json;
 using Enterspeed.Source.Sdk.Api.Services;
 namespace Enterspeed.Source.Sdk.Domain.SystemTextJson

--- a/src/Enterspeed.Source.Sdk/Enterspeed.Source.Sdk.csproj
+++ b/src/Enterspeed.Source.Sdk/Enterspeed.Source.Sdk.csproj
@@ -23,17 +23,17 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[9.0,10.0)" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[9.0,11.0)" />
 		<PackageReference Include="System.Text.Json" Version="[9.0,11.0)" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0,10.0)" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0,11.0)" />
 		<PackageReference Include="System.Text.Json" Version="[5.0,11.0)" />
 	</ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0,10.0)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0,11.0)" />
     <PackageReference Include="System.Text.Json" Version="[5.0,11.0)" />
   </ItemGroup>
 

--- a/src/Enterspeed.Source.Sdk/Enterspeed.Source.Sdk.csproj
+++ b/src/Enterspeed.Source.Sdk/Enterspeed.Source.Sdk.csproj
@@ -22,18 +22,18 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[9.0,11.0)" />
-		<PackageReference Include="System.Text.Json" Version="[9.0,11.0)" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[9.0,10.0)" />
+		<PackageReference Include="System.Text.Json" Version="[9.0,10.0)" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0,11.0)" />
-		<PackageReference Include="System.Text.Json" Version="[5.0,11.0)" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0,10.0)" />
+		<PackageReference Include="System.Text.Json" Version="[5.0,10.0)" />
 	</ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0,11.0)" />
-    <PackageReference Include="System.Text.Json" Version="[5.0,11.0)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0,10.0)" />
+    <PackageReference Include="System.Text.Json" Version="[5.0,10.0)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">

--- a/src/Enterspeed.Source.Sdk/Enterspeed.Source.Sdk.csproj
+++ b/src/Enterspeed.Source.Sdk/Enterspeed.Source.Sdk.csproj
@@ -24,17 +24,17 @@
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[9.0,10.0)" />
-		<PackageReference Include="System.Text.Json" Version="[9.0,10.0)" />
+		<PackageReference Include="System.Text.Json" Version="[9.0,11.0)" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0,10.0)" />
-		<PackageReference Include="System.Text.Json" Version="[5.0,10.0)" />
+		<PackageReference Include="System.Text.Json" Version="[5.0,11.0)" />
 	</ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0,10.0)" />
-    <PackageReference Include="System.Text.Json" Version="[5.0,10.0)" />
+    <PackageReference Include="System.Text.Json" Version="[5.0,11.0)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">

--- a/src/Enterspeed.Source.Sdk/Enterspeed.Source.Sdk.csproj
+++ b/src/Enterspeed.Source.Sdk/Enterspeed.Source.Sdk.csproj
@@ -9,6 +9,7 @@
     <RepositoryUrl>https://github.com/enterspeedhq/enterspeed-sdk-dotnet</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>NU1903;NU1904</NoWarn>
     <PackageProjectUrl>https://github.com/enterspeedhq/enterspeed-sdk-dotnet</PackageProjectUrl>
     <RepositoryType>https://github.com/enterspeedhq/enterspeed-sdk-dotnet</RepositoryType>
     <PackageTags>Enterspeed, SDK, Ingest</PackageTags>

--- a/src/Enterspeed.Source.Sdk/Enterspeed.Source.Sdk.csproj
+++ b/src/Enterspeed.Source.Sdk/Enterspeed.Source.Sdk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.1;netstandard2.0;net6.0;net9.0;</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net6.0;net9.0;net10.0</TargetFrameworks>
     <PackageId>Enterspeed.Source.Sdk</PackageId>
     <Authors>Enterspeed</Authors>
     <Description>.NET SDK for interacting with Enterspeed Ingest API.</Description>
@@ -16,19 +16,24 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
+	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[10.0,11.0)" />
+		<PackageReference Include="System.Text.Json" Version="[10.0,11.0)" />
+	</ItemGroup>
+
 	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[9.0,10.0)" />
-		<PackageReference Include="System.Text.Json" Version="[9.0,10.0)" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[9.0,11.0)" />
+		<PackageReference Include="System.Text.Json" Version="[9.0,11.0)" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0,10.0)" />
-		<PackageReference Include="System.Text.Json" Version="[5.0,10.0)" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0,11.0)" />
+		<PackageReference Include="System.Text.Json" Version="[5.0,11.0)" />
 	</ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0,10.0)" />
-    <PackageReference Include="System.Text.Json" Version="[5.0,10.0)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[5.0,11.0)" />
+    <PackageReference Include="System.Text.Json" Version="[5.0,11.0)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">

--- a/src/Enterspeed.Source.Sdk/Extensions/Setup/ServiceCollectionExtensions.cs
+++ b/src/Enterspeed.Source.Sdk/Extensions/Setup/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0 || NET6_0
+﻿#if NETSTANDARD2_0 || NET6_0_OR_GREATER
 using Enterspeed.Source.Sdk.Api.Connection;
 using Enterspeed.Source.Sdk.Api.Providers;
 using Enterspeed.Source.Sdk.Api.Services;


### PR DESCRIPTION
This pull request adds support for .NET 10 to the SDK, updates dependencies to ensure compatibility with the new framework, and updates build and release configurations accordingly. The changes ensure that the SDK can be built and used with .NET 10 while maintaining compatibility with previous target frameworks.

**.NET 10 Support:**

* Added `net10.0` to the `TargetFrameworks` in `Enterspeed.Source.Sdk.csproj`, enabling compilation for .NET 10.
* Updated the Azure Pipelines configuration to install the .NET 10 SDK during CI builds.

**Dependency Updates:**

* For the `net10.0` target, added package references for `Microsoft.Extensions.DependencyInjection.Abstractions` and `System.Text.Json` version 10.0 or later, ensuring compatibility with .NET 10.
* Broadened the version ranges for these dependencies in other target frameworks to allow compatibility with up to version 11.0.

**Release and Documentation Updates:**

* Bumped the patch version to `2.0.7` in `azure-pipelines.yml` and documented the new version and .NET 10 support in the `CHANGELOG.md`. [[1]](diffhunk://#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5L5-R5) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R14)